### PR TITLE
Various fixes:

### DIFF
--- a/networking/bootstrapper.go
+++ b/networking/bootstrapper.go
@@ -2,6 +2,7 @@ package networking
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
@@ -84,7 +85,7 @@ func (b *bootstrapper) Start() error {
 	defer b.stateMu.Unlock()
 
 	if b.state != bootstrapperUnstarted {
-		panic("bootstrapper has already been started")
+		panic(fmt.Sprintf("cannot start bootstrapper that is not unstarted, state was: %d", b.state))
 	}
 
 	b.state = bootstrapperStarted
@@ -137,10 +138,10 @@ func (b *bootstrapper) setupDHT() (err error) {
 func (b *bootstrapper) Close() error {
 	b.stateMu.Lock()
 	if b.state != bootstrapperStarted {
-		b.stateMu.Unlock()
-		panic("cannot close bootstrapper that is not started")
+		defer b.stateMu.Unlock()
+		panic(fmt.Sprintf("cannot close bootstrapper that is not started, state was: %d", b.state))
 	}
-	b.state = ocrEndpointClosed
+	b.state = bootstrapperClosed
 	b.stateMu.Unlock()
 
 	b.logger.Debug("Bootstrapper: lowering bandwidth limits when closing the bootstrap node", nil)

--- a/networking/knockingtls/limiters.go
+++ b/networking/knockingtls/limiters.go
@@ -74,7 +74,7 @@ func (ls *Limiters) IncreaseLimits(peerIDs []p2ppeer.ID, deltaTokenBucketRefillR
 		// If the new parameters are negative, something went wrong, so log error and remove limiter.
 		newLimit := rcLimiter.refillRate + deltaTokenBucketRefillRate
 		newSize := rcLimiter.limiter.Burst() + deltaTokenBucketSize
-		if newLimit <= 0 || newSize <= 0 {
+		if newLimit < 0 || newSize < 0 {
 			ls.logger.Error("incorrect new bandwith limiter params", types.LogFields{
 				"peerID":         peerID.Pretty(),
 				"newLimit":       newLimit,
@@ -89,7 +89,7 @@ func (ls *Limiters) IncreaseLimits(peerIDs []p2ppeer.ID, deltaTokenBucketRefillR
 			rcLimiter.refillRate = newLimit
 		}
 
-		// Invariant at this point: the limiter for peerID exists and has updated positive params.
+		// Invariant at this point: the limiter for peerID exists and has updated non-negative params.
 
 		// Update reference count for the current limiter. If it's zero, log and remove the limiter.
 		if positiveDeltas {

--- a/offchainreporting/internal/protocol/pacemaker.go
+++ b/offchainreporting/internal/protocol/pacemaker.go
@@ -214,6 +214,8 @@ func (pace *pacemakerState) run() {
 		// ensure prompt exit
 		select {
 		case <-chDone:
+			pace.logger.Info("Pacemaker: winding down", nil)
+			pace.reportGenerationSubprocess.Wait()
 			pace.logger.Info("Pacemaker: exiting", nil)
 			return
 		default:


### PR DESCRIPTION
- better logging in OCREndpoint
- wait for report generation shutdown on pacemaker shutdown
- fix spurious bandwidth limiter error logs

Based on 03e12e32a43229d83ea53e4d791826dfb776dfae