### PR TITLE
Pass contract address when reporting telemetry

### DIFF
--- a/offchainreporting/internal/managed/forward_telemetry.go
+++ b/offchainreporting/internal/managed/forward_telemetry.go
@@ -3,6 +3,7 @@ package managed
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/libocr/offchainreporting/internal/serialization/protobuf"
 	"github.com/smartcontractkit/libocr/offchainreporting/loghelper"
 	"github.com/smartcontractkit/libocr/offchainreporting/types"
@@ -16,6 +17,7 @@ func forwardTelemetry(
 
 	logger loghelper.LoggerWithContext,
 	monitoringEndpoint types.MonitoringEndpoint,
+	contractAddress common.Address,
 
 	chTelemetry <-chan *protobuf.TelemetryWrapper,
 ) {
@@ -37,7 +39,7 @@ func forwardTelemetry(
 				break
 			}
 			if monitoringEndpoint != nil {
-				monitoringEndpoint.SendLog(bin)
+				monitoringEndpoint.SendLog(bin, contractAddress)
 			}
 		case <-ctx.Done():
 			logger.Info("forwardTelemetry: exiting", nil)

--- a/offchainreporting/internal/managed/managed_oracle.go
+++ b/offchainreporting/internal/managed/managed_oracle.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/libocr/offchainreporting/internal/config"
 	"github.com/smartcontractkit/libocr/offchainreporting/internal/protocol"
 	"github.com/smartcontractkit/libocr/offchainreporting/internal/serialization/protobuf"
@@ -30,6 +31,7 @@ func RunManagedOracle(
 	monitoringEndpoint types.MonitoringEndpoint,
 	netEndpointFactory types.BinaryNetworkEndpointFactory,
 	privateKeys types.PrivateKeys,
+	contractAddress common.Address,
 ) {
 	mo := managedOracleState{
 		ctx: ctx,
@@ -44,6 +46,7 @@ func RunManagedOracle(
 		monitoringEndpoint:  monitoringEndpoint,
 		netEndpointFactory:  netEndpointFactory,
 		privateKeys:         privateKeys,
+		contractAddress:     contractAddress,
 	}
 	mo.run()
 }
@@ -62,6 +65,7 @@ type managedOracleState struct {
 	monitoringEndpoint  types.MonitoringEndpoint
 	netEndpointFactory  types.BinaryNetworkEndpointFactory
 	privateKeys         types.PrivateKeys
+	contractAddress     common.Address
 
 	chTelemetry        chan<- *protobuf.TelemetryWrapper
 	netEndpoint        *shim.SerializingEndpoint
@@ -75,7 +79,7 @@ func (mo *managedOracleState) run() {
 		chTelemetry := make(chan *protobuf.TelemetryWrapper, 100)
 		mo.chTelemetry = chTelemetry
 		mo.otherSubprocesses.Go(func() {
-			forwardTelemetry(mo.ctx, mo.logger, mo.monitoringEndpoint, chTelemetry)
+			forwardTelemetry(mo.ctx, mo.logger, mo.monitoringEndpoint, mo.contractAddress, chTelemetry)
 		})
 	}
 

--- a/offchainreporting/oracle.go
+++ b/offchainreporting/oracle.go
@@ -3,6 +3,7 @@ package offchainreporting
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/libocr/offchainreporting/internal/managed"
 	"github.com/smartcontractkit/libocr/offchainreporting/loghelper"
@@ -44,6 +45,9 @@ type OracleArgs struct {
 
 	// Used to send logs to a monitor
 	MonitoringEndpoint types.MonitoringEndpoint
+
+	// The address of the contract
+	ContractAddress common.Address
 
 	// PrivateKeys contains the secret keys needed for the OCR protocol, and methods
 	// which use those keys without exposing them to the rest of the application.
@@ -98,6 +102,7 @@ func (o *Oracle) Start() error {
 			o.oracleArgs.MonitoringEndpoint,
 			o.oracleArgs.BinaryNetworkEndpointFactory,
 			o.oracleArgs.PrivateKeys,
+			o.oracleArgs.ContractAddress,
 		)
 	})
 	return nil

--- a/offchainreporting/types/types.go
+++ b/offchainreporting/types/types.go
@@ -124,7 +124,7 @@ type DataSource interface {
 //
 // All its functions should be thread-safe.
 type MonitoringEndpoint interface {
-	SendLog(log []byte)
+	SendLog(log []byte, contractAddress common.Address)
 }
 
 // ContractTransmitter sends new reports to the OffchainAggregator smart contract.


### PR DESCRIPTION
When we switch to the telemetry ingress replacement for Explorer, we'll need the contract address for each telemetry message to use as a partition key in Kafka. 

This PR aims to pass along the contract address when reporting telemetry so that, in the future, Chainlink can use this in combination with [wsrpc](https://github.com/smartcontractkit/wsrpc) to deliver telemetry to the Explorer replacement.