### PR TITLE
Downgrade log level for API timeout

### DIFF
--- a/offchainreporting/internal/protocol/report_generation_follower.go
+++ b/offchainreporting/internal/protocol/report_generation_follower.go
@@ -367,7 +367,7 @@ func (repgen *reportGenerationState) observeValue() observation.Observation {
 	)
 
 	if !ok {
-		repgen.logger.Error("DataSource timed out", commontypes.LogFields{
+		repgen.logger.Warn("DataSource timed out", commontypes.LogFields{
 			"round":   repgen.followerState.r,
 			"timeout": repgen.localConfig.DataSourceTimeout,
 		})


### PR DESCRIPTION
API timeout is intermittent and is outside of the operator control.


[Log level docs](https://docs.chain.link/docs/configuration-variables/#log_level)
```
"warn": A mild error occurred that might require non-urgent action. Check these warnings semi-regularly to see if any of them require attention. These warnings usually happen due to factors outside of the control of the node operator. Examples: Unexpected responses from a remote API or misleading networking errors.
```