### PR TITLE
Expose Peer interface

### DIFF
--- a/networking/types/types.go
+++ b/networking/types/types.go
@@ -1,6 +1,11 @@
 package types
 
-import "context"
+import (
+	"context"
+
+	ocr1types "github.com/smartcontractkit/libocr/offchainreporting/types"
+	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2/types"
+)
 
 type DiscovererDatabase interface {
 	// StoreAnnouncement has key-value-store semantics and stores a peerID (key) and an associated serialized
@@ -10,4 +15,13 @@ type DiscovererDatabase interface {
 	// ReadAnnouncements returns one serialized announcement (if available) for each of the peerIDs in the form of a map
 	// keyed by each announcement's corresponding peer ID.
 	ReadAnnouncements(ctx context.Context, peerIDs []string) (map[string][]byte, error)
+}
+
+type Peer interface {
+	PeerID() string
+	OCR1BinaryNetworkEndpointFactory() *ocr1types.BinaryNetworkEndpointFactory
+	OCR1BootstrapperFactory() *ocr1types.BootstrapperFactory
+	OCR2BinaryNetworkEndpointFactory() *ocr2types.BinaryNetworkEndpointFactory
+	OCR2BootstrapperFactory() *ocr2types.BootstrapperFactory
+	Close() error
 }


### PR DESCRIPTION
The global function `NewPeer()` starts and returns a *concretePeer struct, but makes it infeasible for an external caller of the library to track and later call `peer.Close()` without separately redefining the `concretePeer` struct or equivalent interface.  This interface exposes the external methods, so that this structure only need to be defined in one repo