### PR TITLE
Added Functions & Threshold plugin digest prefixes

### DIFF
--- a/offchainreporting2plus/types/config_digest.go
+++ b/offchainreporting2plus/types/config_digest.go
@@ -21,6 +21,8 @@ const (
 	ConfigDigestPrefixSolana     ConfigDigestPrefix = 3
 	ConfigDigestPrefixStarknet   ConfigDigestPrefix = 4
 	ConfigDigestPrefixMercuryV02 ConfigDigestPrefix = 6
+	ConfigDigestPrefixThreshold  ConfigDigestPrefix = 7
+	ConfigDigestPrefixFunctions  ConfigDigestPrefix = 8
 	ConfigDigestPrefixOCR1       ConfigDigestPrefix = 0xEEEE // we translate ocr1 config digest to ocr2 config digests in the networking layer
 	_                            ConfigDigestPrefix = 0xFFFF // reserved for future use
 )

--- a/offchainreporting2plus/types/config_digest.go
+++ b/offchainreporting2plus/types/config_digest.go
@@ -21,10 +21,11 @@ const (
 	ConfigDigestPrefixSolana     ConfigDigestPrefix = 3
 	ConfigDigestPrefixStarknet   ConfigDigestPrefix = 4
 	ConfigDigestPrefixMercuryV02 ConfigDigestPrefix = 6
-	ConfigDigestPrefixThreshold  ConfigDigestPrefix = 7
-	ConfigDigestPrefixS4         ConfigDigestPrefix = 8
-	ConfigDigestPrefixOCR1       ConfigDigestPrefix = 0xEEEE // we translate ocr1 config digest to ocr2 config digests in the networking layer
-	_                            ConfigDigestPrefix = 0xFFFF // reserved for future use
+	// Prefixes for running Threshold/S4 plugins as part of another product under one contract.
+	ConfigDigestPrefixThreshold ConfigDigestPrefix = 7
+	ConfigDigestPrefixS4        ConfigDigestPrefix = 8
+	ConfigDigestPrefixOCR1      ConfigDigestPrefix = 0xEEEE // we translate ocr1 config digest to ocr2 config digests in the networking layer
+	_                           ConfigDigestPrefix = 0xFFFF // reserved for future use
 )
 
 // Checks whether a ConfigDigestPrefix is actually a prefix of a ConfigDigest.

--- a/offchainreporting2plus/types/config_digest.go
+++ b/offchainreporting2plus/types/config_digest.go
@@ -22,7 +22,7 @@ const (
 	ConfigDigestPrefixStarknet   ConfigDigestPrefix = 4
 	ConfigDigestPrefixMercuryV02 ConfigDigestPrefix = 6
 	ConfigDigestPrefixThreshold  ConfigDigestPrefix = 7
-	ConfigDigestPrefixFunctions  ConfigDigestPrefix = 8
+	ConfigDigestPrefixS4         ConfigDigestPrefix = 8
 	ConfigDigestPrefixOCR1       ConfigDigestPrefix = 0xEEEE // we translate ocr1 config digest to ocr2 config digests in the networking layer
 	_                            ConfigDigestPrefix = 0xFFFF // reserved for future use
 )


### PR DESCRIPTION
Since each OCR plugin must have a unique config digest, in order to support multiple OCR plugins with a single OCR2Base contract, different prefixes must be used for the configDigest to ensure that each configDigest is unique even though the underlying config data is identical.

These 2 additional configDigest prefixes will support the Threshold decryption plugin and S4 storage plugin for Chainlink Functions.