### PR TITLE
Improvements:

### DIFF
--- a/internal/metricshelper/registerer.go
+++ b/internal/metricshelper/registerer.go
@@ -2,6 +2,7 @@ package metricshelper
 
 import (
 	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/libocr/commontypes"
 )
@@ -22,7 +23,7 @@ func NewPrometheusRegistererWrapper(registerer prometheus.Registerer, logger com
 var _ prometheus.Registerer = (*PrometheusRegistererWrapper)(nil)
 
 func (prw *PrometheusRegistererWrapper) Register(collector prometheus.Collector) error {
-	prw.logger.Debug("Registering collector", nil)
+	prw.logger.Trace("Registering collector", nil)
 	if collector == nil {
 		return fmt.Errorf("tried to register nil collector")
 	}
@@ -38,7 +39,7 @@ func (prw *PrometheusRegistererWrapper) MustRegister(collectors ...prometheus.Co
 }
 
 func (prw *PrometheusRegistererWrapper) Unregister(collector prometheus.Collector) bool {
-	prw.logger.Debug("Unregistering collector", nil)
+	prw.logger.Trace("Unregistering collector", nil)
 	if collector == nil {
 		prw.logger.Warn("Unregistering nil collector", nil)
 		return false

--- a/networking/ragedisco/discovery_protocol.go
+++ b/networking/ragedisco/discovery_protocol.go
@@ -71,7 +71,7 @@ type discoveryProtocol struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	logger    loghelper.LoggerWithContext
-	metrics   discoveryProtocolMetrics
+	metrics   *discoveryProtocolMetrics
 }
 
 const (
@@ -123,7 +123,7 @@ func newDiscoveryProtocol(
 		ctx,
 		ctxCancel,
 		logger.MakeChild(commontypes.LogFields{"id": "discoveryProtocol"}),
-		newDiscoveryProtocolMetrics(metricsRegisterer, ownID.String(), logger),
+		newDiscoveryProtocolMetrics(metricsRegisterer, logger, ownID),
 	}, nil
 }
 

--- a/networking/ragedisco/metrics.go
+++ b/networking/ragedisco/metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/internal/metricshelper"
+	"github.com/smartcontractkit/libocr/ragep2p/types"
 )
 
 type discoveryProtocolMetrics struct {
@@ -13,8 +14,8 @@ type discoveryProtocolMetrics struct {
 	bootstrappers   prometheus.Gauge
 }
 
-func newDiscoveryProtocolMetrics(registerer prometheus.Registerer, peerID string, logger commontypes.Logger) discoveryProtocolMetrics {
-	labels := map[string]string{"peerID": peerID}
+func newDiscoveryProtocolMetrics(registerer prometheus.Registerer, logger commontypes.Logger, peerID types.PeerID) *discoveryProtocolMetrics {
+	labels := map[string]string{"peer_id": peerID.String()}
 
 	registeredPeers := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:        "ragedisco_registered_peers",
@@ -42,7 +43,7 @@ func newDiscoveryProtocolMetrics(registerer prometheus.Registerer, peerID string
 
 	metricshelper.RegisterOrLogError(logger, registerer, bootstrappers, "ragedisco_bootstappers")
 
-	return discoveryProtocolMetrics{
+	return &discoveryProtocolMetrics{
 		registerer,
 		registeredPeers,
 		discoveredPeers,

--- a/offchainreporting2/reportingplugin/median/evmreportcodec/reportcodec.go
+++ b/offchainreporting2/reportingplugin/median/evmreportcodec/reportcodec.go
@@ -32,7 +32,7 @@ var _ median.ReportCodec = ReportCodec{}
 
 type ReportCodec struct{}
 
-func (ReportCodec) BuildReport(paos []median.ParsedAttributedObservation) (types.Report, error) {
+func (ReportCodec) BuildReport(looppctx types.LOOPPContext, paos []median.ParsedAttributedObservation) (types.Report, error) {
 	if len(paos) == 0 {
 		return nil, fmt.Errorf("cannot build report from empty attributed observations")
 	}
@@ -69,7 +69,7 @@ func (ReportCodec) BuildReport(paos []median.ParsedAttributedObservation) (types
 	return types.Report(reportBytes), err
 }
 
-func (ReportCodec) MedianFromReport(report types.Report) (*big.Int, error) {
+func (ReportCodec) MedianFromReport(looppctx types.LOOPPContext, report types.Report) (*big.Int, error) {
 	reportElems := map[string]interface{}{}
 	if err := reportTypes.UnpackIntoMap(reportElems, report); err != nil {
 		return nil, fmt.Errorf("error during unpack: %w", err)
@@ -97,7 +97,7 @@ func (ReportCodec) MedianFromReport(report types.Report) (*big.Int, error) {
 	return median, nil
 }
 
-func (ReportCodec) MaxReportLength(n int) (int, error) {
+func (ReportCodec) MaxReportLength(looppctx types.LOOPPContext, n int) (int, error) {
 	return 32 /* timestamp */ + 32 /* rawObservers */ + (2*32 + n*32) /*observations*/ + 32 /* juelsPerFeeCoin */, nil
 }
 

--- a/offchainreporting2/reportingplugin/titlerequest/titlerequest.go
+++ b/offchainreporting2/reportingplugin/titlerequest/titlerequest.go
@@ -38,7 +38,7 @@ type TitleRequestPluginFactory struct {
 	Contract *ocr2titlerequest.OCR2TitleRequest
 }
 
-func (fac *TitleRequestPluginFactory) NewReportingPlugin(config types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
+func (fac *TitleRequestPluginFactory) NewReportingPlugin(looppctx types.LOOPPContext, config types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
 	return &TitleRequestPlugin{
 			config.F,
 			fac.Client,

--- a/offchainreporting2/types/alias.go
+++ b/offchainreporting2/types/alias.go
@@ -3,6 +3,8 @@ package types
 
 import "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+type LOOPPContext = types.LOOPPContext
+
 type ConfigDigestPrefix = types.ConfigDigestPrefix
 
 const (

--- a/offchainreporting2plus/chains/evmutil/offchain_config_digester.go
+++ b/offchainreporting2plus/chains/evmutil/offchain_config_digester.go
@@ -15,7 +15,7 @@ type EVMOffchainConfigDigester struct {
 	ContractAddress common.Address
 }
 
-func (d EVMOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (types.ConfigDigest, error) {
+func (d EVMOffchainConfigDigester) ConfigDigest(looppctx types.LOOPPContext, cc types.ContractConfig) (types.ConfigDigest, error) {
 	signers := []common.Address{}
 	for i, signer := range cc.Signers {
 		if len(signer) != 20 {
@@ -46,6 +46,6 @@ func (d EVMOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (types.
 	), nil
 }
 
-func (d EVMOffchainConfigDigester) ConfigDigestPrefix() (types.ConfigDigestPrefix, error) {
+func (d EVMOffchainConfigDigester) ConfigDigestPrefix(types.LOOPPContext) (types.ConfigDigestPrefix, error) {
 	return types.ConfigDigestPrefixEVM, nil
 }

--- a/offchainreporting2plus/internal/managed/config_digest.go
+++ b/offchainreporting2plus/internal/managed/config_digest.go
@@ -13,13 +13,13 @@ type prefixCheckConfigDigester struct {
 
 // ConfigDigest method that checks that the computed ConfigDigest's prefix is
 // consistent with OffchainConfigDigester.ConfigDigestPrefix
-func (d prefixCheckConfigDigester) ConfigDigest(cc types.ContractConfig) (types.ConfigDigest, error) {
-	prefix, err := d.offchainConfigDigester.ConfigDigestPrefix()
+func (d prefixCheckConfigDigester) ConfigDigest(looppctx types.LOOPPContext, cc types.ContractConfig) (types.ConfigDigest, error) {
+	prefix, err := d.offchainConfigDigester.ConfigDigestPrefix(looppctx)
 	if err != nil {
 		return types.ConfigDigest{}, err
 	}
 
-	cd, err := d.offchainConfigDigester.ConfigDigest(cc)
+	cd, err := d.offchainConfigDigester.ConfigDigest(looppctx, cc)
 	if err != nil {
 		return types.ConfigDigest{}, err
 	}
@@ -33,8 +33,8 @@ func (d prefixCheckConfigDigester) ConfigDigest(cc types.ContractConfig) (types.
 
 // Check that the ContractConfig's ConfigDigest matches the one computed
 // offchain
-func (d prefixCheckConfigDigester) CheckContractConfig(cc types.ContractConfig) error {
-	goodConfigDigest, err := d.ConfigDigest(cc)
+func (d prefixCheckConfigDigester) CheckContractConfig(looppctx types.LOOPPContext, cc types.ContractConfig) error {
+	goodConfigDigest, err := d.ConfigDigest(looppctx, cc)
 	if err != nil {
 		return err
 	}

--- a/offchainreporting2plus/internal/managed/managed_mercury_oracle.go
+++ b/offchainreporting2plus/internal/managed/managed_mercury_oracle.go
@@ -63,7 +63,7 @@ func RunManagedMercuryOracle(
 		func(ctx context.Context, contractConfig types.ContractConfig, logger loghelper.LoggerWithContext) {
 			skipResourceExhaustionChecks := localConfig.DevelopmentMode == types.EnableDangerousDevelopmentMode
 
-			fromAccount, err := contractTransmitter.FromAccount()
+			fromAccount, err := contractTransmitter.FromAccount(ctx)
 			if err != nil {
 				logger.Error("ManagedMercuryOracle: error getting FromAccount", commontypes.LogFields{
 					"error": err,
@@ -98,7 +98,7 @@ func RunManagedMercuryOracle(
 				"oid": oid,
 			})
 
-			mercuryPlugin, mercuryPluginInfo, err := mercuryPluginFactory.NewMercuryPlugin(ocr3types.MercuryPluginConfig{
+			mercuryPlugin, mercuryPluginInfo, err := mercuryPluginFactory.NewMercuryPlugin(ctx, ocr3types.MercuryPluginConfig{
 				sharedConfig.ConfigDigest,
 				oid,
 				sharedConfig.N(),
@@ -123,9 +123,9 @@ func RunManagedMercuryOracle(
 			registerer := prometheus.WrapRegistererWith(
 				prometheus.Labels{
 					// disambiguate different protocol instances by configDigest
-					"configDigest": sharedConfig.ConfigDigest.String(),
+					"config_digest": sharedConfig.ConfigDigest.String(),
 					// disambiguate different oracle instances by offchainPublicKey
-					"offchainPublicKey": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
+					"offchain_public_key": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
 				},
 				metricsRegistererWrapper,
 			)

--- a/offchainreporting2plus/internal/managed/managed_ocr2_oracle.go
+++ b/offchainreporting2plus/internal/managed/managed_ocr2_oracle.go
@@ -65,7 +65,7 @@ func RunManagedOCR2Oracle(
 		func(ctx context.Context, contractConfig types.ContractConfig, logger loghelper.LoggerWithContext) {
 			skipResourceExhaustionChecks := localConfig.DevelopmentMode == types.EnableDangerousDevelopmentMode
 
-			fromAccount, err := contractTransmitter.FromAccount()
+			fromAccount, err := contractTransmitter.FromAccount(ctx)
 			if err != nil {
 				logger.Error("ManagedOCR2Oracle: error getting FromAccount", commontypes.LogFields{
 					"error": err,
@@ -91,9 +91,9 @@ func RunManagedOCR2Oracle(
 			registerer := prometheus.WrapRegistererWith(
 				prometheus.Labels{
 					// disambiguate different protocol instances by configDigest
-					"configDigest": sharedConfig.ConfigDigest.String(),
+					"config_digest": sharedConfig.ConfigDigest.String(),
 					// disambiguate different oracle instances by offchainPublicKey
-					"offchainPublicKey": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
+					"offchain_public_key": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
 				},
 				metricsRegistererWrapper,
 			)
@@ -108,7 +108,7 @@ func RunManagedOCR2Oracle(
 				"oid": oid,
 			})
 
-			reportingPlugin, reportingPluginInfo, err := reportingPluginFactory.NewReportingPlugin(types.ReportingPluginConfig{
+			reportingPlugin, reportingPluginInfo, err := reportingPluginFactory.NewReportingPlugin(ctx, types.ReportingPluginConfig{
 				sharedConfig.ConfigDigest,
 				oid,
 				sharedConfig.N(),

--- a/offchainreporting2plus/internal/managed/managed_ocr3_oracle.go
+++ b/offchainreporting2plus/internal/managed/managed_ocr3_oracle.go
@@ -62,7 +62,7 @@ func RunManagedOCR3Oracle[RI any](
 		func(ctx context.Context, contractConfig types.ContractConfig, logger loghelper.LoggerWithContext) {
 			skipResourceExhaustionChecks := localConfig.DevelopmentMode == types.EnableDangerousDevelopmentMode
 
-			fromAccount, err := contractTransmitter.FromAccount()
+			fromAccount, err := contractTransmitter.FromAccount(ctx)
 			if err != nil {
 				logger.Error("ManagedOCR3Oracle: error getting FromAccount", commontypes.LogFields{
 					"error": err,
@@ -88,9 +88,9 @@ func RunManagedOCR3Oracle[RI any](
 			registerer := prometheus.WrapRegistererWith(
 				prometheus.Labels{
 					// disambiguate different protocol instances by configDigest
-					"configDigest": sharedConfig.ConfigDigest.String(),
+					"config_digest": sharedConfig.ConfigDigest.String(),
 					// disambiguate different oracle instances by offchainPublicKey
-					"offchainPublicKey": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
+					"offchain_public_key": fmt.Sprintf("%x", offchainKeyring.OffchainPublicKey()),
 				},
 				metricsRegistererWrapper,
 			)
@@ -105,7 +105,7 @@ func RunManagedOCR3Oracle[RI any](
 				"oid": oid,
 			})
 
-			reportingPlugin, reportingPluginInfo, err := reportingPluginFactory.NewReportingPlugin(ocr3types.ReportingPluginConfig{
+			reportingPlugin, reportingPluginInfo, err := reportingPluginFactory.NewReportingPlugin(ctx, ocr3types.ReportingPluginConfig{
 				sharedConfig.ConfigDigest,
 				oid,
 				sharedConfig.N(),

--- a/offchainreporting2plus/internal/managed/run_with_contract_config.go
+++ b/offchainreporting2plus/internal/managed/run_with_contract_config.go
@@ -123,7 +123,7 @@ func (rwcc *runWithContractConfigState) configChanged(contractConfig types.Contr
 	})
 
 	// note that there is an analogous check in TrackConfig, so this should never trigger.
-	if err := rwcc.configDigester.CheckContractConfig(contractConfig); err != nil {
+	if err := rwcc.configDigester.CheckContractConfig(rwcc.ctx, contractConfig); err != nil {
 		rwcc.logger.Error("runWithContractConfig: detected corruption while attempting to change configuration", commontypes.LogFields{
 			"err":            err,
 			"contractConfig": contractConfig,

--- a/offchainreporting2plus/internal/managed/track_config.go
+++ b/offchainreporting2plus/internal/managed/track_config.go
@@ -140,7 +140,7 @@ func (state *trackConfigState) checkLatestConfigDetails() (
 
 	// Ignore configs where the configDigest doesn't match, they might have
 	// been corrupted somehow.
-	if err := state.configDigester.CheckContractConfig(contractConfig); err != nil {
+	if err := state.configDigester.CheckContractConfig(state.ctx, contractConfig); err != nil {
 		state.logger.Error("TrackConfig: received corrupted config change", commontypes.LogFields{
 			"error":          err,
 			"contractConfig": contractConfig,

--- a/offchainreporting2plus/internal/mercuryshim/mercuryshims.go
+++ b/offchainreporting2plus/internal/mercuryshim/mercuryshims.go
@@ -94,8 +94,8 @@ func (t *MercuryOCR3ContractTransmitter) Transmit(
 	)
 }
 
-func (t *MercuryOCR3ContractTransmitter) FromAccount() (types.Account, error) {
-	return t.ocr2ContractTransmitter.FromAccount()
+func (t *MercuryOCR3ContractTransmitter) FromAccount(looppctx types.LOOPPContext) (types.Account, error) {
+	return t.ocr2ContractTransmitter.FromAccount(looppctx)
 }
 
 func ocr3MaxOutcomeLength(maxReportLength int) int {
@@ -171,22 +171,22 @@ func (p *MercuryReportingPlugin) Observation(ctx context.Context, outctx ocr3typ
 	return observation, nil
 }
 
-func (p *MercuryReportingPlugin) ValidateObservation(outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation) error {
+func (p *MercuryReportingPlugin) ValidateObservation(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation) error {
 	return nil
 }
 
-func (p *MercuryReportingPlugin) ObservationQuorum(outctx ocr3types.OutcomeContext, query types.Query) (ocr3types.Quorum, error) {
+func (p *MercuryReportingPlugin) ObservationQuorum(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query) (ocr3types.Quorum, error) {
 	return ocr3types.QuorumTwoFPlusOne, nil
 }
 
-func (p *MercuryReportingPlugin) Outcome(outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
+func (p *MercuryReportingPlugin) Outcome(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
 	previousOutcomeDeserialized, err := deserializeMercuryReportingPluginOutcome(outctx.PreviousOutcome)
 	if err != nil {
 		return nil, err
 	}
 
 	//nolint:staticcheck
-	shouldReport, report, err := p.Plugin.Report(types.ReportTimestamp{p.Config.ConfigDigest, uint32(outctx.Epoch), uint8(outctx.Round)}, previousOutcomeDeserialized.Report, aos)
+	shouldReport, report, err := p.Plugin.Report(looppctx, types.ReportTimestamp{p.Config.ConfigDigest, uint32(outctx.Epoch), uint8(outctx.Round)}, previousOutcomeDeserialized.Report, aos)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (p *MercuryReportingPlugin) Outcome(outctx ocr3types.OutcomeContext, query 
 	return serializeMercuryReportingPluginOutcome(outcomeDeserialized), nil
 }
 
-func (p *MercuryReportingPlugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[MercuryReportInfo], error) {
+func (p *MercuryReportingPlugin) Reports(looppctx types.LOOPPContext, seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[MercuryReportInfo], error) {
 	outcomeDeserialized, err := deserializeMercuryReportingPluginOutcome(outcome)
 	if err != nil {
 		return nil, err

--- a/offchainreporting2plus/internal/ocr2/protocol/metrics.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/metrics.go
@@ -13,7 +13,7 @@ type pacemakerMetrics struct {
 }
 
 func newPacemakerMetrics(registerer prometheus.Registerer,
-	logger commontypes.Logger) pacemakerMetrics {
+	logger commontypes.Logger) *pacemakerMetrics {
 	epoch := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ocr2_epoch",
 		Help: "The total number of initialized epochs",
@@ -26,7 +26,7 @@ func newPacemakerMetrics(registerer prometheus.Registerer,
 	})
 	metricshelper.RegisterOrLogError(logger, registerer, leader, "ocr2_experimental_leader_oid")
 
-	return pacemakerMetrics{
+	return &pacemakerMetrics{
 		registerer,
 		epoch,
 		leader,
@@ -36,4 +36,65 @@ func newPacemakerMetrics(registerer prometheus.Registerer,
 func (pm *pacemakerMetrics) Close() {
 	pm.registerer.Unregister(pm.epoch)
 	pm.registerer.Unregister(pm.leader)
+}
+
+type reportGenerationMetrics struct {
+	registerer                prometheus.Registerer
+	sentObservationsTotal     prometheus.Counter
+	includedObservationsTotal prometheus.Counter
+	completedRoundsTotal      prometheus.Counter
+	ledCompletedRoundsTotal   prometheus.Counter
+}
+
+func newReportGenerationMetrics(registerer prometheus.Registerer,
+	logger commontypes.Logger) *reportGenerationMetrics {
+
+	sentObservationsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr2_sent_observations_total",
+		Help: "The total number of observations by this oracle sent to the leader. Note that a " +
+			"sent observation might not arrive at the leader in time, or not be included in a " +
+			"report request for other reasons. This metric is useful for checking an oracle's " +
+			"ability to make observations.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, sentObservationsTotal, "ocr2_sent_observations_total")
+
+	includedObservationsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr2_included_observations_total",
+		Help: "The total number of observations by this oracle included in a report request " +
+			"from the leader. Note that there is no guarantee that the report request will " +
+			"actually lead to a report; for instance, because the leader crashes or maliciously " +
+			"equivocates to make this oracle believe that an observation was included. This " +
+			"metric is useful in comparison with ocr2_sent_observations_total to check whether " +
+			"an oracle is able to regularly make observations that are included in report requests.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, includedObservationsTotal, "ocr2_included_observations_total")
+
+	completedRoundsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr2_completed_rounds_total",
+		Help: "The total number of rounds completed by this oracle. A round can be completed by " +
+			"the oracle's ReportingPlugin deciding to skip the round or by the creation of a report.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, completedRoundsTotal, "ocr2_completed_rounds_total")
+
+	ledCompletedRoundsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr2_led_completed_rounds_total",
+		Help: "The total number of completed rounds led by this oracle. This metric is useful " +
+			"for checking an oracle's ability to act as leader.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, ledCompletedRoundsTotal, "ocr2_led_completed_rounds_total")
+
+	return &reportGenerationMetrics{
+		registerer,
+		sentObservationsTotal,
+		includedObservationsTotal,
+		completedRoundsTotal,
+		ledCompletedRoundsTotal,
+	}
+}
+
+func (m *reportGenerationMetrics) Close() {
+	m.registerer.Unregister(m.sentObservationsTotal)
+	m.registerer.Unregister(m.includedObservationsTotal)
+	m.registerer.Unregister(m.completedRoundsTotal)
+	m.registerer.Unregister(m.ledCompletedRoundsTotal)
 }

--- a/offchainreporting2plus/internal/ocr2/protocol/oracle.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/oracle.go
@@ -115,8 +115,8 @@ type oracleState struct {
 // to Pacemaker and ReportGeneration. It will then cancel o.childCtx,
 // making all children exit. To prevent deadlocks, all channel sends and
 // receives in Oracle, Pacemaker, ReportGeneration, Transmission, etc...
-// are contained in select{} statements that also contain a case for context
-// cancellation.
+// are (1) contained in select{} statements that also contain a case for context
+// cancellation or (2) guaranteed to occur before o.childCtx is cancelled.
 //
 // Finally, all sub-goroutines spawned in the protocol are attached to o.subprocesses
 // (with the exception of ReportGeneration which is explicitly managed by Pacemaker).
@@ -143,6 +143,8 @@ func (o *oracleState) run() {
 
 	chReportFinalizationToTransmission := make(chan EventToTransmission)
 
+	// be careful if you want to change anything here.
+	// chNetTo* sends in message.go assume that their recipients are running.
 	o.childCtx, o.childCancel = context.WithCancel(context.Background())
 	defer o.childCancel()
 

--- a/offchainreporting2plus/internal/ocr2/protocol/pacemaker.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/pacemaker.go
@@ -91,6 +91,7 @@ func makePacemakerState(
 		netSender:                              netSender,
 		offchainKeyring:                        offchainKeyring,
 		onchainKeyring:                         onchainKeyring,
+		reportGenerationMetrics:                newReportGenerationMetrics(metricsRegisterer, logger),
 		reportingPlugin:                        reportingPlugin,
 		reportQuorum:                           reportQuorum,
 		telemetrySender:                        telemetrySender,
@@ -114,10 +115,11 @@ type pacemakerState struct {
 	id                                     commontypes.OracleID
 	localConfig                            types.LocalConfig
 	logger                                 loghelper.LoggerWithContext
-	metrics                                pacemakerMetrics
+	metrics                                *pacemakerMetrics
 	netSender                              NetworkSender
 	offchainKeyring                        types.OffchainKeyring
 	onchainKeyring                         types.OnchainKeyring
+	reportGenerationMetrics                *reportGenerationMetrics
 	reportingPlugin                        types.ReportingPlugin
 	reportQuorum                           int
 	telemetrySender                        TelemetrySender
@@ -234,6 +236,7 @@ func (pace *pacemakerState) run() {
 			pace.logger.Info("Pacemaker: winding down", nil)
 			pace.reportGenerationSubprocess.Wait()
 			pace.metrics.Close()
+			pace.reportGenerationMetrics.Close()
 			pace.logger.Info("Pacemaker: exiting", nil)
 			return
 		default:
@@ -493,6 +496,7 @@ func (pace *pacemakerState) spawnReportGeneration() {
 			netSender,
 			offchainKeyring,
 			onchainKeyring,
+			reportGenerationMetrics,
 			reportingPlugin,
 			reportQuorum,
 			telemetrySender := pace.subprocesses,
@@ -508,6 +512,7 @@ func (pace *pacemakerState) spawnReportGeneration() {
 			pace.netSender,
 			pace.offchainKeyring,
 			pace.onchainKeyring,
+			pace.reportGenerationMetrics,
 			pace.reportingPlugin,
 			pace.reportQuorum,
 			pace.telemetrySender
@@ -531,6 +536,7 @@ func (pace *pacemakerState) spawnReportGeneration() {
 				netSender,
 				offchainKeyring,
 				onchainKeyring,
+				reportGenerationMetrics,
 				reportingPlugin,
 				reportQuorum,
 				telemetrySender,

--- a/offchainreporting2plus/internal/ocr2/protocol/report_generation.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/report_generation.go
@@ -29,6 +29,7 @@ func RunReportGeneration(
 	netSender NetworkSender,
 	offchainKeyring types.OffchainKeyring,
 	onchainKeyring types.OnchainKeyring,
+	reportGenerationMetrics *reportGenerationMetrics,
 	reportingPlugin types.ReportingPlugin,
 	reportQuorum int,
 	telemetrySender TelemetrySender,
@@ -50,6 +51,7 @@ func RunReportGeneration(
 		netSender:                              netSender,
 		offchainKeyring:                        offchainKeyring,
 		onchainKeyring:                         onchainKeyring,
+		reportGenerationMetrics:                reportGenerationMetrics,
 		reportingPlugin:                        reportingPlugin,
 		reportQuorum:                           reportQuorum,
 		telemetrySender:                        telemetrySender,
@@ -74,6 +76,7 @@ type reportGenerationState struct {
 	netSender                              NetworkSender
 	offchainKeyring                        types.OffchainKeyring
 	onchainKeyring                         types.OnchainKeyring
+	reportGenerationMetrics                *reportGenerationMetrics
 	reportingPlugin                        types.ReportingPlugin
 	reportQuorum                           int
 	telemetrySender                        TelemetrySender

--- a/offchainreporting2plus/internal/ocr2/protocol/report_generation_leader.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/report_generation_leader.go
@@ -87,7 +87,7 @@ func (repgen *reportGenerationState) startRound() {
 			actualMaxDurationQuery+ReportingPluginTimeoutWarningGracePeriod,
 			func() {
 				repgen.logger.Error("ReportGeneration: ReportingPlugin.Query is taking too long", commontypes.LogFields{
-					"round": repgen.leaderState.r, "maxDuration": actualMaxDurationQuery,
+					"round": repgen.leaderState.r, "maxDuration": actualMaxDurationQuery.String(),
 				})
 			},
 		)
@@ -318,6 +318,11 @@ func (repgen *reportGenerationState) messageReport(msg MessageReport, sender com
 		}
 
 		if repgen.reportQuorum <= len(ass) {
+			repgen.reportGenerationMetrics.ledCompletedRoundsTotal.Inc()
+			repgen.logger.Info("led round to completion", commontypes.LogFields{
+				"skip":  msg.AttestedReport.Skip,
+				"round": repgen.leaderState.r,
+			})
 			if !msg.AttestedReport.Skip {
 				repgen.netSender.Broadcast(MessageFinal{
 					repgen.e,

--- a/offchainreporting2plus/internal/ocr2/protocol/transmission.go
+++ b/offchainreporting2plus/internal/ocr2/protocol/transmission.go
@@ -154,7 +154,7 @@ func (t *transmissionState) eventTransmit(ev EventTransmit) {
 			t.config.MaxDurationShouldAcceptFinalizedReport+ReportingPluginTimeoutWarningGracePeriod,
 			func() {
 				t.logger.Error("Transmission: ReportingPlugin.ShouldAcceptFinalizedReport is taking too long", commontypes.LogFields{
-					"epoch": ev.Epoch, "round": ev.Round, "maxDuration": t.config.MaxDurationShouldAcceptFinalizedReport,
+					"epoch": ev.Epoch, "round": ev.Round, "maxDuration": t.config.MaxDurationShouldAcceptFinalizedReport.String(),
 				})
 			},
 		)
@@ -251,7 +251,7 @@ func (t *transmissionState) eventTTransmitTimeout() {
 			t.config.MaxDurationShouldTransmitAcceptedReport+ReportingPluginTimeoutWarningGracePeriod,
 			func() {
 				t.logger.Error("Transmission: ReportingPlugin.ShouldTransmitAcceptedReport is taking too long", commontypes.LogFields{
-					"item": item, "maxDuration": t.config.MaxDurationShouldTransmitAcceptedReport,
+					"item": item, "maxDuration": t.config.MaxDurationShouldTransmitAcceptedReport.String(),
 				})
 			},
 		)
@@ -291,7 +291,7 @@ func (t *transmissionState) eventTTransmitTimeout() {
 			t.localConfig.ContractTransmitterTransmitTimeout+ContractTransmitterTimeoutWarningGracePeriod,
 			func() {
 				t.logger.Error("Transmission: ContractTransmitter.Transmit is taking too long", commontypes.LogFields{
-					"item": item, "maxDuration": t.localConfig.ContractTransmitterTransmitTimeout,
+					"item": item, "maxDuration": t.localConfig.ContractTransmitterTransmitTimeout.String(),
 				})
 			},
 		)

--- a/offchainreporting2plus/internal/ocr3/protocol/metrics.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/metrics.go
@@ -13,7 +13,7 @@ type pacemakerMetrics struct {
 }
 
 func newPacemakerMetrics(registerer prometheus.Registerer,
-	logger commontypes.Logger) pacemakerMetrics {
+	logger commontypes.Logger) *pacemakerMetrics {
 
 	epoch := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ocr3_epoch",
@@ -27,7 +27,7 @@ func newPacemakerMetrics(registerer prometheus.Registerer,
 	})
 	metricshelper.RegisterOrLogError(logger, registerer, leader, "ocr3_experimental_leader_oid")
 
-	return pacemakerMetrics{
+	return &pacemakerMetrics{
 		registerer,
 		epoch,
 		leader,
@@ -40,25 +40,61 @@ func (pm *pacemakerMetrics) Close() {
 }
 
 type outcomeGenerationMetrics struct {
-	registerer     prometheus.Registerer
-	committedSeqNr prometheus.Gauge
+	registerer                prometheus.Registerer
+	committedSeqNr            prometheus.Gauge
+	sentObservationsTotal     prometheus.Counter
+	includedObservationsTotal prometheus.Counter
+	ledCommittedRoundsTotal   prometheus.Counter
 }
 
 func newOutcomeGenerationMetrics(registerer prometheus.Registerer,
-	logger commontypes.Logger) outcomeGenerationMetrics {
+	logger commontypes.Logger) *outcomeGenerationMetrics {
 
 	committedSeqNr := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ocr3_committed_sequence_number",
-		Help: "The total number of committed sequence numbers",
+		Help: "The committed sequence number",
 	})
 	metricshelper.RegisterOrLogError(logger, registerer, committedSeqNr, "ocr3_committed_sequence_number")
 
-	return outcomeGenerationMetrics{
+	sentObservationsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr3_sent_observations_total",
+		Help: "The total number of observations by this oracle sent to the leader. Note that a " +
+			"sent observation might not arrive at the leader in time, or not be included in a " +
+			"proposal for other reasons. This metric is useful for checking an oracle's ability " +
+			"to make observations.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, sentObservationsTotal, "ocr3_sent_observations_total")
+
+	includedObservationsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr3_included_observations_total",
+		Help: "The total number of (valid) observations by this oracle included in a proposal " +
+			"from the leader. Note that there is no guarantee that the proposal will actually get " +
+			"committed; for instance, because the leader crashes or maliciously equivocates to " +
+			"make this oracle believe that an observation was included. This metric is useful in " +
+			"comparison with ocr3_sent_observations_total to check whether an oracle is able to " +
+			"regularly make observations that are included in proposals.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, includedObservationsTotal, "ocr3_included_observations_total")
+
+	ledCommittedRoundsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ocr3_led_committed_rounds_total",
+		Help: "The total number of rounds committed that were led by this oracle. This metric is " +
+			"useful for checking an oracle's ability to act as leader.",
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, ledCommittedRoundsTotal, "ocr3_led_committed_rounds_total")
+
+	return &outcomeGenerationMetrics{
 		registerer,
 		committedSeqNr,
+		sentObservationsTotal,
+		includedObservationsTotal,
+		ledCommittedRoundsTotal,
 	}
 }
 
 func (om *outcomeGenerationMetrics) Close() {
 	om.registerer.Unregister(om.committedSeqNr)
+	om.registerer.Unregister(om.sentObservationsTotal)
+	om.registerer.Unregister(om.includedObservationsTotal)
+	om.registerer.Unregister(om.ledCommittedRoundsTotal)
 }

--- a/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_leader.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_leader.go
@@ -281,13 +281,13 @@ func (outgen *outcomeGenerationState[RI]) messageObservation(msg MessageObservat
 		return
 	}
 
-	err, ok := callPluginFromOutcomeGeneration[error](
+	err, ok := callPluginWithLOOPPContextFromOutcomeGeneration[error](
 		outgen,
 		"ValidateObservation",
-		0, // ValidateObservation is a pure function and should finish "instantly"
 		outgen.OutcomeCtx(outgen.sharedState.seqNr),
-		func(ctx context.Context, outctx ocr3types.OutcomeContext) (error, error) {
+		func(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext) (error, error) {
 			return outgen.reportingPlugin.ValidateObservation(
+				looppctx,
 				outctx,
 				outgen.leaderState.query,
 				types.AttributedObservation{msg.SignedObservation.Observation, sender},

--- a/offchainreporting2plus/internal/ocr3/protocol/pacemaker.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/pacemaker.go
@@ -90,7 +90,7 @@ type pacemakerState[RI any] struct {
 	id                             commontypes.OracleID
 	localConfig                    types.LocalConfig
 	logger                         loghelper.LoggerWithContext
-	metrics                        pacemakerMetrics
+	metrics                        *pacemakerMetrics
 	netSender                      NetworkSender[RI]
 	offchainKeyring                types.OffchainKeyring
 	telemetrySender                TelemetrySender

--- a/offchainreporting2plus/internal/ocr3/protocol/report_attestation.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/report_attestation.go
@@ -443,9 +443,15 @@ func (repatt *reportAttestationState[RI]) receivedCertifiedCommit(certifiedCommi
 		repatt.logger,
 		commontypes.LogFields{"seqNr": certifiedCommit.SeqNr},
 		"Reports",
-		0, // Reports is a pure function and should finish "instantly"
-		func(context.Context) ([]ocr3types.ReportWithInfo[RI], error) {
+		// Setting to 0 because we don't pass this context to the plugin
+		// function and we expect functions that receive a LOOPPContext to
+		// return "immediately". callPlugin will log an error if the plugin
+		// function takes longer than ReportingPluginTimeoutWarningGracePeriod.
+		0,
+		func(_ context.Context) ([]ocr3types.ReportWithInfo[RI], error) {
 			return repatt.reportingPlugin.Reports(
+				// Important: we use repatt.ctx here
+				types.LOOPPContext(repatt.ctx),
 				certifiedCommit.SeqNr,
 				certifiedCommit.Outcome,
 			)

--- a/offchainreporting2plus/internal/ocr3/protocol/transmission.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/transmission.go
@@ -187,7 +187,7 @@ func (t *transmissionState[RI]) scheduled(ev EventAttestedReport[RI]) {
 			t.localConfig.ContractTransmitterTransmitTimeout+ContractTransmitterTimeoutWarningGracePeriod,
 			func() {
 				t.logger.Error("ContractTransmitter.Transmit is taking too long", commontypes.LogFields{
-					"maxDuration": t.localConfig.ContractTransmitterTransmitTimeout,
+					"maxDuration": t.localConfig.ContractTransmitterTransmitTimeout.String(),
 					"seqNr":       ev.SeqNr,
 					"index":       ev.Index,
 				})

--- a/offchainreporting2plus/internal/shim/ocr3_reporting_plugin.go
+++ b/offchainreporting2plus/internal/shim/ocr3_reporting_plugin.go
@@ -31,8 +31,8 @@ func (rp LimitCheckOCR3ReportingPlugin[RI]) Query(ctx context.Context, outctx oc
 	return query, nil
 }
 
-func (rp LimitCheckOCR3ReportingPlugin[RI]) ObservationQuorum(outctx ocr3types.OutcomeContext, query types.Query) (ocr3types.Quorum, error) {
-	return rp.Plugin.ObservationQuorum(outctx, query)
+func (rp LimitCheckOCR3ReportingPlugin[RI]) ObservationQuorum(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query) (ocr3types.Quorum, error) {
+	return rp.Plugin.ObservationQuorum(looppctx, outctx, query)
 }
 
 func (rp LimitCheckOCR3ReportingPlugin[RI]) Observation(ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query) (types.Observation, error) {
@@ -46,12 +46,12 @@ func (rp LimitCheckOCR3ReportingPlugin[RI]) Observation(ctx context.Context, out
 	return observation, nil
 }
 
-func (rp LimitCheckOCR3ReportingPlugin[RI]) ValidateObservation(outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation) error {
-	return rp.Plugin.ValidateObservation(outctx, query, ao)
+func (rp LimitCheckOCR3ReportingPlugin[RI]) ValidateObservation(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation) error {
+	return rp.Plugin.ValidateObservation(looppctx, outctx, query, ao)
 }
 
-func (rp LimitCheckOCR3ReportingPlugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
-	outcome, err := rp.Plugin.Outcome(outctx, query, aos)
+func (rp LimitCheckOCR3ReportingPlugin[RI]) Outcome(looppctx types.LOOPPContext, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
+	outcome, err := rp.Plugin.Outcome(looppctx, outctx, query, aos)
 	if err != nil {
 		return nil, err
 	}
@@ -61,8 +61,8 @@ func (rp LimitCheckOCR3ReportingPlugin[RI]) Outcome(outctx ocr3types.OutcomeCont
 	return outcome, nil
 }
 
-func (rp LimitCheckOCR3ReportingPlugin[RI]) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[RI], error) {
-	reports, err := rp.Plugin.Reports(seqNr, outcome)
+func (rp LimitCheckOCR3ReportingPlugin[RI]) Reports(looppctx types.LOOPPContext, seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[RI], error) {
+	reports, err := rp.Plugin.Reports(looppctx, seqNr, outcome)
 	if err != nil {
 		return nil, err
 	}

--- a/offchainreporting2plus/ocr3types/counting_mercury_plugin.go
+++ b/offchainreporting2plus/ocr3types/counting_mercury_plugin.go
@@ -18,7 +18,7 @@ func (p *CountingMercuryPlugin) Observation(ctx context.Context, repts types.Rep
 	return []byte{byte(rand.Int() % 2)}, nil
 }
 
-func (p *CountingMercuryPlugin) Report(repts types.ReportTimestamp, previousReport types.Report, aos []types.AttributedObservation) (bool, types.Report, error) {
+func (p *CountingMercuryPlugin) Report(looppctx types.LOOPPContext, repts types.ReportTimestamp, previousReport types.Report, aos []types.AttributedObservation) (bool, types.Report, error) {
 	report := make([]byte, 4)
 	if len(previousReport) == 0 {
 		if p.initializedReport {
@@ -58,7 +58,7 @@ func (p *CountingMercuryPlugin) Close() error {
 
 type CountingMercuryPluginFactory struct{}
 
-func (fac *CountingMercuryPluginFactory) NewMercuryPlugin(_ MercuryPluginConfig) (MercuryPlugin, MercuryPluginInfo, error) {
+func (fac *CountingMercuryPluginFactory) NewMercuryPlugin(_ types.LOOPPContext, _ MercuryPluginConfig) (MercuryPlugin, MercuryPluginInfo, error) {
 	return &CountingMercuryPlugin{},
 		MercuryPluginInfo{
 			"CountingMercuryPlugin", MercuryPluginLimits{

--- a/offchainreporting2plus/ocr3types/mercury_plugin.go
+++ b/offchainreporting2plus/ocr3types/mercury_plugin.go
@@ -12,7 +12,7 @@ type MercuryPluginFactory interface {
 	// Creates a new mercury-specific reporting plugin instance. The instance may have
 	// associated goroutines or hold system resources, which should be
 	// released when its Close() function is called.
-	NewMercuryPlugin(MercuryPluginConfig) (MercuryPlugin, MercuryPluginInfo, error)
+	NewMercuryPlugin(types.LOOPPContext, MercuryPluginConfig) (MercuryPlugin, MercuryPluginInfo, error)
 }
 
 type MercuryPluginConfig struct {
@@ -127,7 +127,7 @@ type MercuryPlugin interface {
 	// You may assume that the sequence of epochs and the sequence of rounds
 	// within an epoch are monotonically increasing during the lifetime
 	// of an instance of this interface.
-	Report(repts types.ReportTimestamp, previousReport types.Report, aos []types.AttributedObservation) (bool, types.Report, error)
+	Report(looppctx types.LOOPPContext, repts types.ReportTimestamp, previousReport types.Report, aos []types.AttributedObservation) (bool, types.Report, error)
 
 	// If Close is called a second time, it may return an error but must not
 	// panic. This will always be called when a ReportingPlugin is no longer

--- a/offchainreporting2plus/ocr3types/types.go
+++ b/offchainreporting2plus/ocr3types/types.go
@@ -27,7 +27,7 @@ type ContractTransmitter[RI any] interface {
 	) error
 
 	// Account from which the transmitter invokes the contract
-	FromAccount() (types.Account, error)
+	FromAccount(types.LOOPPContext) (types.Account, error)
 }
 
 // OnchainKeyring provides cryptographic signatures that need to be verifiable

--- a/offchainreporting2plus/types/config_digest.go
+++ b/offchainreporting2plus/types/config_digest.go
@@ -98,8 +98,8 @@ func (c ConfigDigest) MarshalText() (text []byte, err error) {
 type OffchainConfigDigester interface {
 	// Compute ConfigDigest for the given ContractConfig. The first two bytes of the
 	// ConfigDigest must be the big-endian encoding of ConfigDigestPrefix!
-	ConfigDigest(ContractConfig) (ConfigDigest, error)
+	ConfigDigest(LOOPPContext, ContractConfig) (ConfigDigest, error)
 
 	// This should return the same constant value on every invocation
-	ConfigDigestPrefix() (ConfigDigestPrefix, error)
+	ConfigDigestPrefix(LOOPPContext) (ConfigDigestPrefix, error)
 }

--- a/offchainreporting2plus/types/context.go
+++ b/offchainreporting2plus/types/context.go
@@ -1,0 +1,25 @@
+package types
+
+import "context"
+
+// LOOPPContext is passed to functions that run in [local out-of-process
+// plugins] and that were originally executed in the same
+// process as OCR protocol logic.
+// In the LOOPP architecture, these functions are executed in a different
+// process (with very low round-trip latency, on the order of a millisecond in
+// the typical case).
+//
+// Implementers of an interface function receiving such a context are
+// responsible for ensuring that their function:
+//   - returns quickly. This is important so as not to block protocol logic.
+//   - doesn't perform remote network calls or other "slow" operations that are
+//     allowed to run until context expiry.
+//   - passes the LOOPPContext to other functions called down the stack. This is
+//     to enable OpenTelemetry Tracing.
+//
+// Note that not all functions running in LOOPPs receive a LOOPPContext. Other
+// functions that are expected to potentially run until context expiry receive
+// a regular context.Context.
+//
+// [local out-of-process plugins]: https://github.com/smartcontractkit/chainlink-common/blob/main/pkg/loop/README.md?rgh-link-date=2024-03-19T16%3A48%3A39Z
+type LOOPPContext = context.Context

--- a/offchainreporting2plus/types/types.go
+++ b/offchainreporting2plus/types/types.go
@@ -88,7 +88,7 @@ type ReportingPluginFactory interface {
 	// Creates a new reporting plugin instance. The instance may have
 	// associated goroutines or hold system resources, which should be
 	// released when its Close() function is called.
-	NewReportingPlugin(ReportingPluginConfig) (ReportingPlugin, ReportingPluginInfo, error)
+	NewReportingPlugin(LOOPPContext, ReportingPluginConfig) (ReportingPlugin, ReportingPluginInfo, error)
 }
 
 type ReportingPluginConfig struct {
@@ -327,7 +327,7 @@ type ContractTransmitter interface {
 	)
 
 	// Account from which the transmitter invokes the contract
-	FromAccount() (Account, error)
+	FromAccount(LOOPPContext) (Account, error)
 }
 
 // ContractConfigTracker tracks configuration changes of the OCR contract

--- a/ragep2p/conn_rate_limiter.go
+++ b/ragep2p/conn_rate_limiter.go
@@ -57,6 +57,16 @@ func (crl *connRateLimiter) AddTokens(n uint32) {
 	crl.limiter.AddTokens(n)
 }
 
+func (crl *connRateLimiter) TokenBucketParams() TokenBucketParams {
+	crl.mutex.Lock()
+	defer crl.mutex.Unlock()
+
+	return TokenBucketParams{
+		float64(crl.limiter.Rate()) / 1000, // millitokens per second -> tokens per second
+		crl.limiter.Capacity(),
+	}
+}
+
 func (crl *connRateLimiter) addRemoveStream(add bool, messagesLimit TokenBucketParams, bytesLimit TokenBucketParams) {
 	if crl.infiniteRate {
 		// we're already in absorbing overflow state, nothing to be done

--- a/ragep2p/doc.go
+++ b/ragep2p/doc.go
@@ -85,4 +85,43 @@
 // Stream.Close(), Stream.SendMessage(), and Stream.Receive() return immediately
 // and do any potential resulting communication asynchronously in the
 // background. Host.Close() terminates after at most a few seconds.
+//
+// # Metrics
+//
+// ragep2p exposes prometheus metrics. Their names are prefixed with "ragep2p_".
+// The audience for these metrics are operators of software using ragep2p and
+// developers building on top of ragep2p.
+//
+// # Suggested Health Checks
+//
+// The following example health checks in PromQL enable operators to monitor
+// connectivity to remote peers and health of connections with them. We
+// suggest monitoring *all* of these metrics. These examples only serve as a
+// starting point, operators are encouraged to adjust thresholds empirically
+// and come up with more sophisticated queries.
+//
+// Is my ragep2p host receiving data from the remote peer? If not, there is a
+// connectivity problem.
+//
+//	rate(ragep2p_peer_conn_read_processed_bytes_total[5m]) > 0
+//
+// Is my ragep2p host sending data to the remote peer? If not, there is a
+// connectivity problem.
+//
+//	rate(ragep2p_peer_conn_written_bytes_total[5m]) > 0
+//
+// Is connection churn reasonable (e.g. less than one new connection every 3m)?
+// If not, this may point to infrastructure or ISP problems.
+//
+//	rate(ragep2p_peer_conn_established_total[10m]) < 1/(3 * 60)
+//
+// Is my ragep2p host not skipping any data received from the remote peer? if
+// not, this may point to bugs in the software running on top of ragep2p.
+//
+//	rate(ragep2p_peer_conn_read_skipped_bytes_total[5m]) == 0
+//
+// Is my ragep2p host receiving inbound dials at all? If not, this may point
+// to a misconfiguration in my infrastructure.
+//
+//	rate(ragep2p_host_inbound_dials_total[48h]) > 0
 package ragep2p

--- a/ragep2p/metrics.go
+++ b/ragep2p/metrics.go
@@ -1,0 +1,169 @@
+package ragep2p
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/internal/metricshelper"
+	"github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+type hostMetrics struct {
+	registerer        prometheus.Registerer
+	inboundDialsTotal prometheus.Counter
+}
+
+func newHostMetrics(registerer prometheus.Registerer, logger commontypes.Logger, self types.PeerID) *hostMetrics {
+	labels := map[string]string{"peer_id": self.String()}
+
+	inboundDialsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_host_inbound_dials_total",
+		Help:        "The number of inbound dial attempts received by the host",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, inboundDialsTotal, "ragep2p_host_inbound_dials_total")
+
+	return &hostMetrics{
+		registerer,
+		inboundDialsTotal,
+	}
+}
+
+func (m *hostMetrics) Close() {
+	m.registerer.Unregister(m.inboundDialsTotal)
+}
+
+type peerMetrics struct {
+	registerer                  prometheus.Registerer
+	connEstablishedTotal        prometheus.Counter
+	connEstablishedInboundTotal prometheus.Counter
+	connReadProcessedBytesTotal prometheus.Counter
+	connReadSkippedBytesTotal   prometheus.Counter
+	connWrittenBytesTotal       prometheus.Counter
+	rawconnReadBytesTotal       prometheus.Counter
+	rawconnWrittenBytesTotal    prometheus.Counter
+	rawconnRateLimitRate        prometheus.Gauge
+	rawconnRateLimitCapacity    prometheus.Gauge
+	messageBytes                prometheus.Histogram
+}
+
+func newPeerMetrics(registerer prometheus.Registerer, logger commontypes.Logger, self types.PeerID, other types.PeerID) *peerMetrics {
+	labels := map[string]string{"peer_id": self.String(), "remote_peer_id": other.String()}
+
+	connEstablishedTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_peer_conn_established_total",
+		Help:        "The number of secure connections established with the remote peer. At most one connection can be active at any time.",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, connEstablishedTotal, "ragep2p_peer_conn_established_total")
+
+	connEstablishedInboundTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_peer_conn_established_inbound_total",
+		Help:        "The number of secure connections established with the remote peer from inbound dials. At most one connection can be active at any time.",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, connEstablishedInboundTotal, "ragep2p_peer_conn_established_inbound_total")
+
+	connReadProcessedBytesTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_peer_conn_read_processed_bytes_total",
+		Help:        "The number of bytes read on secure connections with the remote peer for processing",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, connReadProcessedBytesTotal, "ragep2p_peer_conn_read_processed_bytes_total")
+
+	connReadSkippedBytesTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_peer_conn_read_skipped_bytes_total",
+		Help:        "The number of bytes read on secure connections with the remote peer that have been skipped, e.g. due to rate limits being exceeded",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, connReadSkippedBytesTotal, "ragep2p_peer_conn_read_skipped_bytes_total")
+
+	connWrittenBytesTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ragep2p_peer_conn_written_bytes_total",
+		Help:        "The number of bytes written on secure connections with the remote peer",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, connWrittenBytesTotal, "ragep2p_peer_conn_written_bytes_total")
+
+	rawconnReadBytesTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ragep2p_peer_rawconn_read_bytes_total",
+		Help: "The number of raw bytes read on raw (post-knock, tcp) connections with the remote " +
+			"peer. Knocks are ~100 bytes and thus have negligible impact. This metric is useful for " +
+			"tracking overall bandwidth usage.",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, rawconnReadBytesTotal, "ragep2p_peer_rawconn_read_bytes_total")
+
+	rawconnWrittenBytesTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "ragep2p_peer_rawconn_written_bytes_total",
+		Help: "The number of raw bytes written on raw (post-knock, tcp) connections with the remote " +
+			"peer. Knocks are ~100 bytes and thus have negligible impact. This metric is useful for " +
+			"tracking overall bandwidth usage.",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, rawconnWrittenBytesTotal, "ragep2p_peer_rawconn_written_bytes_total")
+
+	rawconnRateLimitRate := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "ragep2p_peer_rawconn_rate_limit_rate",
+		Help:        "The refill rate in bytes per second for the token bucket rate limiting reads from raw connections with the remote peer",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, rawconnRateLimitRate, "ragep2p_peer_rawconn_rate_limit_rate")
+
+	rawconnRateLimitCapacity := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        "ragep2p_peer_rawconn_rate_limit_capacity",
+		Help:        "The capacity in bytes for the token bucket rate limiting reads from raw connections with the remote peer",
+		ConstLabels: labels,
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, rawconnRateLimitCapacity, "ragep2p_peer_rawconn_rate_limit_capacity")
+
+	messageBytes := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:        "ragep2p_experimental_peer_message_bytes",
+		Help:        "The size of messages sent to the remote peer",
+		ConstLabels: labels,
+		Buckets:     []float64{1 << 8, 1 << 10, 1 << 12, 1 << 14, 1 << 16, 1 << 18, 1 << 20, 1 << 22, 1 << 24, 1 << 26, 1 << 28}, // 256 bytes, 1KiB, ..., 256MiB
+	})
+
+	metricshelper.RegisterOrLogError(logger, registerer, messageBytes, "ragep2p_experimental_peer_message_bytes")
+
+	return &peerMetrics{
+		registerer,
+		connEstablishedTotal,
+		connEstablishedInboundTotal,
+		connReadProcessedBytesTotal,
+		connReadSkippedBytesTotal,
+		connWrittenBytesTotal,
+		rawconnReadBytesTotal,
+		rawconnWrittenBytesTotal,
+		rawconnRateLimitRate,
+		rawconnRateLimitCapacity,
+		messageBytes,
+	}
+}
+
+func (m *peerMetrics) Close() {
+	m.registerer.Unregister(m.connEstablishedTotal)
+	m.registerer.Unregister(m.connEstablishedInboundTotal)
+	m.registerer.Unregister(m.connReadProcessedBytesTotal)
+	m.registerer.Unregister(m.connReadSkippedBytesTotal)
+	m.registerer.Unregister(m.connWrittenBytesTotal)
+	m.registerer.Unregister(m.rawconnReadBytesTotal)
+	m.registerer.Unregister(m.rawconnWrittenBytesTotal)
+	m.registerer.Unregister(m.rawconnRateLimitRate)
+	m.registerer.Unregister(m.rawconnRateLimitCapacity)
+	m.registerer.Unregister(m.messageBytes)
+}
+
+func (m *peerMetrics) SetConnRateLimit(tokenBucketParams TokenBucketParams) {
+	m.rawconnRateLimitRate.Set(tokenBucketParams.Rate)
+	m.rawconnRateLimitCapacity.Set(float64(tokenBucketParams.Capacity))
+}


### PR DESCRIPTION
- Improve support for LOOPPs (local out-of-process plugins) by passing LOOPPContexts to functions that are expected to run inside LOOPPs and didn't previously receive a Context.
- Enhance prometheus metric coverage. New metrics for ragep2p, ocr2 report generation, ocr3 outcome generation.
- Rename some metric labels to follow the prometheus convention of snake_case instead of camelCase.
- Improve various docs and comments.
- Future-proof ocr3types.Quorum constants for an increase of MaxOracles.

Based on dff1e61bfe0b5d75f373eda2803a0f7fc286ad91