### PR TITLE
Improvements:

### DIFF
--- a/networking/rageping/metrics.go
+++ b/networking/rageping/metrics.go
@@ -1,0 +1,108 @@
+package rageping
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/internal/metricshelper"
+
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+type latencyMetrics struct {
+	// Be careful about the field order here and during initialization.
+	registerer prometheus.Registerer
+
+	// Captures the round-trip time of a PING/PONG message pair between this host and the remote peer.
+	roundTripLatencySeconds prometheus.Histogram
+
+	// Counts the number of outgoing PING messages sent to the remote peer.
+	sentRequestsTotal prometheus.Counter
+
+	// Counts the number of valid incoming PING messages received from the remote peer.
+	receivedRequestsTotal prometheus.Counter
+
+	// Counts the number of PING messages for which no valid PONG message was received in time from the remote peer.
+	timedOutRequestsTotal prometheus.Counter
+
+	// Counts the number of other invalid messages received from the remote peer.
+	// An invalid message could be of invalid size, have an invalid message type, or be late PONG message.
+	invalidMessagesReceivedTotal prometheus.Counter
+}
+
+func newLatencyMetrics(
+	registerer prometheus.Registerer,
+	logger commontypes.Logger,
+	peerID ragetypes.PeerID,
+	remotePeerID ragetypes.PeerID,
+	config *LatencyMetricsServiceConfig,
+) *latencyMetrics {
+	constLabels := prometheus.Labels{
+		"peer_id":        peerID.String(),
+		"remote_peer_id": remotePeerID.String(),
+		"ping_size":      fmt.Sprint(config.PingSize),
+		"min_period":     fmt.Sprint(config.MinPeriod),
+		"max_period":     fmt.Sprint(config.MaxPeriod),
+		"timeout":        fmt.Sprint(config.Timeout),
+	}
+
+	roundTripLatencyBuckets := config.Buckets
+	if config.Buckets == nil {
+		roundTripLatencyBuckets = DefaultLatencyBuckets()
+	}
+	roundTripLatencySeconds := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:        "rageping_round_trip_latency_seconds",
+		Help:        "The round trip latency, i.e., the time between sending a PING to receiving the corresponding PONG.",
+		ConstLabels: constLabels,
+		Buckets:     roundTripLatencyBuckets,
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, roundTripLatencySeconds, "rageping_round_trip_latency_seconds")
+
+	sentRequestsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "rageping_sent_requests_total",
+		Help:        "The number of PING requests sent to the remote peer.",
+		ConstLabels: constLabels,
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, sentRequestsTotal, "rageping_sent_requests_total")
+
+	receivedRequestsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "rageping_received_requests_total",
+		Help:        "The number of PING requests received from the remote remote peer.",
+		ConstLabels: constLabels,
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, receivedRequestsTotal, "rageping_received_requests_total")
+
+	timedOutRequestsTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "rageping_timed_out_requests_total",
+		Help:        "The number of PING requests sent to the remote peer, for which no (valid) response was received before the configured timeout.",
+		ConstLabels: constLabels,
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, timedOutRequestsTotal, "rageping_timed_out_requests_total")
+
+	invalidMessagesReceivedTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "rageping_invalid_messages_received_total",
+		Help:        "The number of invalid messages received from the remote peer. These are expected rarely due to restarts of the underlying network connection.",
+		ConstLabels: constLabels,
+	})
+	metricshelper.RegisterOrLogError(logger, registerer, invalidMessagesReceivedTotal, "rageping_invalid_messages_received_total")
+
+	// Be careful about the initialization order. peer_test.go tests that the metrics below are indeed exposed and
+	// updated. Be sure to update peer_test.go when changing the metric names here.
+	return &latencyMetrics{
+		registerer,
+		roundTripLatencySeconds,
+		sentRequestsTotal,
+		receivedRequestsTotal,
+		timedOutRequestsTotal,
+		invalidMessagesReceivedTotal,
+	}
+}
+
+func (m *latencyMetrics) Close() {
+	m.registerer.Unregister(m.roundTripLatencySeconds)
+	m.registerer.Unregister(m.sentRequestsTotal)
+	m.registerer.Unregister(m.receivedRequestsTotal)
+	m.registerer.Unregister(m.timedOutRequestsTotal)
+	m.registerer.Unregister(m.invalidMessagesReceivedTotal)
+}

--- a/networking/rageping/service.go
+++ b/networking/rageping/service.go
@@ -1,0 +1,519 @@
+package rageping
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/internal/loghelper"
+	"github.com/smartcontractkit/libocr/ragep2p"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	unsafeRand "math/rand"
+)
+
+type latencyMetricsService struct {
+	host              *ragep2p.Host
+	metricsRegisterer prometheus.Registerer
+	logger            loghelper.LoggerWithContext
+	peerStates        map[ragetypes.PeerID]*latencyMetricsPeerState
+	config            *LatencyMetricsServiceConfig
+	streamConfig      *latencyMetricsServiceStreamLimits
+
+	// Mutex ensuring that the interface functions are thread safe.
+	mu sync.Mutex
+}
+
+// A smaller wrapper which runs a LatencyMetricsService instead for each passed configuration.
+// Calls are are simply forwarded to the internal instances.
+type latencyMetricsServiceGroup struct {
+	instances []LatencyMetricsService
+}
+
+var _ LatencyMetricsService = &latencyMetricsService{}
+var _ LatencyMetricsService = &latencyMetricsServiceGroup{}
+
+// Request format:
+//   - message type: 1 => request/ping; 4 bytes big-endian
+//   - payload: random fill bytes to achieve the desired request/response size, must contain at least 128 bits of
+//     cryptographically secure randomness.
+//
+// Response format:
+//   - message type: 2 => response/pong; 4 bytes big-endian
+//   - request hash: SHA2-256 hash of the corresponding request; 32 bytes
+
+const (
+	msgTypePing uint32 = 1
+	msgTypePong uint32 = 2
+	minPingSize int    = 20
+	pongSize    int    = 4 + 32
+)
+
+// Internal struct holding the state for each remote peer.
+type latencyMetricsPeerState struct {
+	// Exposed prometheus metrics; cleaned up when refCount reaches zero.
+	metrics *latencyMetrics
+
+	// Main stream used for sending/receiving PING/PONG messages.
+	stream *ragep2p.Stream
+
+	// A reference counter for the number of times this particular peer has been registered. Only a single state is
+	// kept per peer (and config). Registering the same peer multiple times does not create a new ping/pong protocol
+	// instance but rather only increases the reference count. Whenever it reached zero, the underlying resources
+	// (metrics, and stream) are cleaned up, and this state is removed from the service's state map.
+	refCount int
+
+	// Channel indicating when the main ping/pong protocol has terminated (after a shutdown was requested).
+	chDone chan struct{}
+}
+
+func (s *latencyMetricsPeerState) Done() chan struct{} {
+	return s.chDone
+}
+
+// Struct holding all the configuration parameters required to set up the stream for the underlying service
+// configuration. Correct values are computed from latencyMetricsServiceConfig during service initialization.
+type latencyMetricsServiceStreamLimits struct {
+	outgoingBufferSize int
+	incomingBufferSize int
+	maxMessageLength   int
+	messagesLimit      ragep2p.TokenBucketParams
+	bytesLimit         ragep2p.TokenBucketParams
+}
+
+func (c *LatencyMetricsServiceConfig) getStreamLimits() *latencyMetricsServiceStreamLimits {
+	// We are sending and receiving ping and pong messages, so the outgoing and incoming buffers must be able to hold
+	// the larger of the two message types.
+	maxMessageLength := c.PingSize
+	if pongSize > c.PingSize {
+		maxMessageLength = pongSize
+	}
+
+	// A new message is only sent after receiving a response or after a timeout, so really a bufferSize of 1 is fine.
+	// Buffer sizes are specified in number of messages (and not in bytes).
+	outgoingBufferSize := 1
+	incomingBufferSize := 1
+
+	// There is at most one ping and one pong message received per c.minPeriod. (Only the inbound messages are
+	// considered for the rate limits.)
+	msgsCapacity := uint32(2 + 1 /* margin of error */)
+	msgsRate := 2.0 / c.MinPeriod.Seconds()
+	msgsLimit := ragep2p.TokenBucketParams{msgsRate, msgsCapacity}
+	bytesCapacity := uint32((c.PingSize + pongSize) * 2)
+	bytesRate := float64(bytesCapacity) / c.MinPeriod.Seconds()
+	bytesLimit := ragep2p.TokenBucketParams{bytesRate, bytesCapacity}
+
+	return &latencyMetricsServiceStreamLimits{
+		outgoingBufferSize,
+		incomingBufferSize,
+		maxMessageLength,
+		msgsLimit,
+		bytesLimit,
+	}
+}
+
+// Register a list of (new) peers and executes the ping-pong protocol between this host and each peer. If a peer was
+// already added by a prior call to this function, it is not added again - only its reference count is incremented.
+func (s *latencyMetricsService) RegisterPeers(peerIDs []ragetypes.PeerID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.logger.Trace("latencyMetricsService.RegisterPeers", commontypes.LogFields{"remotePeerIDs": peerIDs})
+
+	for _, peerID := range peerIDs {
+		// Ignore registration request for the host itself.
+		if s.host.ID() == peerID {
+			continue
+		}
+
+		if peerState, keyExists := s.peerStates[peerID]; keyExists {
+			// A ping/pong instance is already running for this peer, therefore only increment reference count.
+			peerState.refCount += 1
+			continue
+		}
+
+		// At this point in the code, we know that no ping/pong instance is running for the given peer.
+		// Initialize and start a new instance below.
+		s.logger.Info("initializing rageping instance", commontypes.LogFields{"remotePeerID": peerID})
+
+		stream, err := s.initStream(peerID)
+		if err != nil {
+			s.logger.Error(
+				"initializing rageping instance failed (initStream call failed)",
+				commontypes.LogFields{"error": err, "remotePeerID": peerID},
+			)
+			continue
+		}
+
+		metrics := newLatencyMetrics(s.metricsRegisterer, s.logger, s.host.ID(), peerID, s.config)
+		refCount := 1
+		peerState := &latencyMetricsPeerState{metrics, stream, refCount, make(chan struct{})}
+		s.peerStates[peerID] = peerState
+
+		go s.run(peerID, peerState)
+		s.logger.Info("initializing rageping instance completed", commontypes.LogFields{"remotePeerID": peerID})
+	}
+}
+
+// Unregister a list of peers. If we only have a single registration for a particular peer, the underlying
+// resources are freed. Otherwise, only the reference count is decremented, but the ping/pong protocol continues to
+// execute until UnregisterPeers is called once for each call to RegisterPeers.
+func (s *latencyMetricsService) UnregisterPeers(peerIDs []ragetypes.PeerID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.logger.Trace("latencyMetricsService.UnregisterPeers", commontypes.LogFields{"remotePeerIDs": peerIDs})
+
+	for _, peerID := range peerIDs {
+		// Ignore unregistration request for the host itself, registration is ignored already, so there is no
+		// possibility that the host itself was registered, and therefore it cannot (and does not need to be)
+		// unregistered.
+		if s.host.ID() == peerID {
+			continue
+		}
+
+		peerState, keyExists := s.peerStates[peerID]
+		if !keyExists {
+			s.logger.Error(
+				"failed to unregister peer from latency metrics service (not registered)",
+				commontypes.LogFields{
+					"remotePeerID": peerID.String(),
+				},
+			)
+			continue
+		}
+
+		// Decrement refCount and check if we need to cleanup resources or if other registrations prevent that.
+		peerState.refCount -= 1
+		if peerState.refCount > 0 {
+			continue
+		}
+
+		// Here, refCount reached zero. Therefore, all resources are cleaned up below.
+
+		// Close the underlying stream, this will cause the primary service loop to exit.
+		if err := peerState.stream.Close(); err != nil {
+			s.logger.Warn("failed to close stream", commontypes.LogFields{"error": err})
+		}
+
+		// Wait for the primary loop to be shutdown.
+		<-peerState.Done()
+
+		peerState.metrics.Close()
+
+		delete(s.peerStates, peerID)
+	}
+}
+
+func (s *latencyMetricsService) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, peerState := range s.peerStates {
+		// Close the underlying stream, this will cause the primary service loop to exit.
+		if err := peerState.stream.Close(); err != nil {
+			s.logger.Warn("failed to close stream", commontypes.LogFields{"error": err})
+		}
+		<-peerState.Done()
+		peerState.metrics.Close()
+	}
+
+	// Clear all peerStates.
+	s.peerStates = make(map[ragetypes.PeerID]*latencyMetricsPeerState)
+}
+
+// Forward the RegisterPeers to each underlying service instance.
+func (sg *latencyMetricsServiceGroup) RegisterPeers(peerIDs []ragetypes.PeerID) {
+	for _, instance := range sg.instances {
+		instance.RegisterPeers(peerIDs)
+	}
+}
+
+// Forward the UnregisterPeers call to each underlying service instance.
+func (sg *latencyMetricsServiceGroup) UnregisterPeers(peerIDs []ragetypes.PeerID) {
+	for _, instance := range sg.instances {
+		instance.UnregisterPeers(peerIDs)
+	}
+}
+
+// Forward the Close call to each underlying service instance.
+func (sg *latencyMetricsServiceGroup) Close() {
+	for _, instance := range sg.instances {
+		instance.Close()
+	}
+}
+
+func (s *latencyMetricsService) initStream(peerID ragetypes.PeerID) (*ragep2p.Stream, error) {
+	// Get a unique stream name for each configuration.
+	streamName := fmt.Sprintf(
+		"ping-pong-(%v|%v|%v|%v)", s.config.PingSize, s.config.MinPeriod, s.config.MaxPeriod, s.config.Timeout,
+	)
+
+	return s.host.NewStream(
+		peerID,
+		streamName,
+		s.streamConfig.outgoingBufferSize,
+		s.streamConfig.incomingBufferSize,
+		s.streamConfig.maxMessageLength,
+		s.streamConfig.messagesLimit,
+		s.streamConfig.bytesLimit,
+	)
+}
+
+// Return a uniformly-at-random selected duration from the interval [s.config.MinPeriod, s.config.MaxPeriod].
+func (s *latencyMetricsService) getNextDelay() time.Duration {
+	// Get a random value in the range 0.0 to 1.0.
+	r := unsafeRand.Float64()
+
+	// Scale the value of r to size of the interval [0, maxPeriod-minPeriod].
+	r *= float64(s.config.MaxPeriod - s.config.MinPeriod)
+
+	// Shift the value of r to interval [minPeriod, maxPeriod].
+	return time.Duration(r) + s.config.MinPeriod
+
+	// The above uniform distribution should be simple and sufficient for our purposes.
+	// If we really want to get fancy, something like the following would be possible:
+	//
+	// def get_random_delay(MIN, AVG, MAX):
+	//     # Calculate alpha and beta based on the desired average
+	//         alpha = AVG - MIN
+	//         beta = MAX - AVG
+	//
+	//     # Scaling factor to adjust alpha and beta for better shape handling
+	//     scale = 0.5
+	//     alpha *= scale
+	//     beta *= scale
+	//
+	//     return MIN + (MAX - MIN) * random.betavariate(alpha, beta)
+}
+
+func (s *latencyMetricsService) preparePingMessage() ([]byte, error) {
+	// Initialize the message buffer and set the pingMsg type to PING.
+	pingMsg := make([]byte, s.config.PingSize)
+	binary.BigEndian.PutUint32(pingMsg, msgTypePing)
+
+	// Randomly generate a tag and extra fill bytes.
+	if _, err := rand.Read(pingMsg[4:]); err != nil {
+		s.logger.Error(
+			"internal call to preparePingMessage() failed unexpectedly",
+			commontypes.LogFields{"error": err},
+		)
+		return nil, err
+	}
+
+	return pingMsg, nil
+}
+
+func (s *latencyMetricsService) preparePongMessage(pingMsg []byte) ([]byte, error) {
+	// Initialize the message buffer and set the pingMessage type to PONG.
+	pongMsg := make([]byte, 4, pongSize)
+	binary.BigEndian.PutUint32(pongMsg, msgTypePong)
+
+	// Compute the response value as the hash over the request data and append it to the response.
+	hasher := sha256.New()
+	_, err := hasher.Write(pingMsg)
+	if err != nil {
+		s.logger.Error(
+			"internal call to preparePongMessage() failed unexpectedly",
+			commontypes.LogFields{"error": err},
+		)
+		return nil, err
+	}
+	pongMsg = hasher.Sum(pongMsg)
+
+	// Here response holds:
+	//  - [0: 4]  the value 1 (message type: response/pong)
+	//  - [4:36]  the hash of request
+	return pongMsg, nil
+}
+
+// Core ping-pong protocol between the host and the given remote peer. After an initial startup delay, the protocol,
+// in some regular (but somewhat randomized) interval, sends out a ping messages to the remote peer and measures the
+// round-trip-time until a response is received . When a ping is received from the remote peer, it responds with the
+// corresponding pong.
+func (s *latencyMetricsService) run(remotePeerID ragetypes.PeerID, peerState *latencyMetricsPeerState) {
+	s.logger.Info("starting rageping instance", commontypes.LogFields{"remotePeerID": remotePeerID})
+	defer func() {
+		s.logger.Info("stopping rageping instance", commontypes.LogFields{"remotePeerID": remotePeerID})
+		close(peerState.chDone)
+	}()
+
+	stream := peerState.stream
+	metrics := peerState.metrics
+
+	ticker := time.NewTicker(s.config.StartupDelay + s.getNextDelay())
+	defer ticker.Stop()
+
+	var lastPingSentAt time.Time
+	var expectedPongMsg []byte
+
+	for {
+		select {
+		case <-ticker.C:
+			// Check if we are currently waiting for a PONG message.
+			if expectedPongMsg == nil {
+				// The ticker event triggered, but we are not waiting for a PONG message, therefore:
+				//  1. Send a PING message.
+				//  2. Configure the ticker such that the next tick event is triggered after the configured timeout for
+				//     receiving the corresponding PONG message.
+				lastPingSentAt, expectedPongMsg = s.sendPing(remotePeerID, stream, metrics)
+				ticker.Reset(s.config.Timeout)
+			} else {
+				// The ticker event triggered, and we are currently awaiting a PONG message. So no PONG message was
+				// received before the configured timeout, therefore:
+				//  1. Stop waiting for the expected PONG message.
+				//  2. Log this timeout and update metrics accordingly.
+				//  3. Reschedule the ticker for sending a new PING message.
+				expectedPongMsg = nil
+				s.processTimedOutPing(remotePeerID, metrics)
+				ticker.Reset(s.getNextDelay())
+			}
+
+		case msg, ok := <-stream.ReceiveMessages():
+			if !ok {
+				// Stream was closed, so we are shutting down.
+				return
+			}
+
+			// Some message was received from the remote peer.
+			//  - For an incoming (valid) PING message: respond with the corresponding PONG message.
+			//  - For an incoming (valid) PONG message:
+			//      1. Stop waiting for the PONG message.
+			//      2. Measure latency and update metrics.
+			//      3. Reschedule the ticker for sending a new PING message.
+			//  - Log invalid messages.
+			if len(msg) >= 4 {
+				msgType := binary.BigEndian.Uint32(msg)
+				if msgType == msgTypePing && len(msg) == s.config.PingSize {
+					s.processIncomingPingMessage(msg, remotePeerID, stream, metrics)
+					break
+				}
+				if msgType == msgTypePong && len(msg) == pongSize {
+					if s.processIncomingPongMessage(msg, expectedPongMsg, lastPingSentAt, remotePeerID, metrics) {
+						expectedPongMsg = nil
+						ticker.Reset(s.getNextDelay())
+					}
+					break
+				}
+			}
+
+			// Truncate long messages before logging them. Using minPingSize here is just some suitable value,
+			// other small values are equally good.
+			msgPrefix := msg
+			if len(msg) > minPingSize {
+				msgPrefix = msg[:minPingSize]
+			}
+
+			s.logger.Warn(
+				"invalid message received",
+				commontypes.LogFields{"remotePeerID": remotePeerID, "msgPrefix": msgPrefix, "msgLen": len(msg)},
+			)
+			metrics.invalidMessagesReceivedTotal.Inc()
+		}
+	}
+}
+
+func (s *latencyMetricsService) sendPing(
+	remotePeerID ragetypes.PeerID, stream *ragep2p.Stream, metrics *latencyMetrics,
+) (lastPingSentAt time.Time, expectedPongMsg []byte) {
+	// Generate a new random PING message to be sent to the remote peer.
+	pingMsg, err := s.preparePingMessage()
+	if err != nil {
+		return
+	}
+
+	// For the above PING message, compute the PONG message we expect the remote peer to respond with.
+	expectedPongMsg, err = s.preparePongMessage(pingMsg)
+	if err != nil {
+		return
+	}
+
+	// Actually send the PING message and keep track of the current time to compute the latency when we
+	// receive corresponding PONG message.
+	lastPingSentAt = time.Now()
+	stream.SendMessage(pingMsg)
+	metrics.sentRequestsTotal.Inc()
+	s.logger.Trace(
+		"sending PING",
+		commontypes.LogFields{
+			"remotePeerID": remotePeerID, "msgPrefix": pingMsg[:minPingSize], "msgLen": len(pingMsg),
+		},
+	)
+	return
+}
+
+func (s *latencyMetricsService) processTimedOutPing(remotePeerID ragetypes.PeerID, metrics *latencyMetrics) {
+	// expectedPongMessage != nil
+	// No PONG message for was received before the configured timeout.
+	s.logger.Debug(
+		"peer failed to respond to last PING request in time",
+		commontypes.LogFields{"remotePeerID": remotePeerID},
+	)
+	metrics.timedOutRequestsTotal.Inc()
+}
+
+func (s *latencyMetricsService) processIncomingPingMessage(
+	pingMsg []byte,
+	remotePeerID ragetypes.PeerID,
+	stream *ragep2p.Stream,
+	metrics *latencyMetrics,
+) {
+	// Some valid PING message was received from the remote peer.
+	s.logger.Trace(
+		"PING received",
+		commontypes.LogFields{
+			"remotePeerID": remotePeerID, "msgPrefix": pingMsg[:minPingSize], "msgLen": len(pingMsg),
+		},
+	)
+	metrics.receivedRequestsTotal.Inc()
+
+	// Respond with the corresponding PONG message.
+	pongMsg, err := s.preparePongMessage(pingMsg)
+	if err != nil {
+		return
+	}
+
+	s.logger.Trace("sending PONG", commontypes.LogFields{"remotePeerID": remotePeerID, "msg": pongMsg})
+	stream.SendMessage(pongMsg)
+}
+
+func (s *latencyMetricsService) processIncomingPongMessage(
+	pongMsg []byte,
+	expectedPongMsg []byte,
+	lastPingSentAt time.Time,
+	remotePeerID ragetypes.PeerID,
+	metrics *latencyMetrics,
+) bool {
+	// Some (valid or invalid) PONG message was received from the remote peer.
+	if bytes.Equal(pongMsg, expectedPongMsg) {
+		// The value matches the expected one, so the PONG message is valid and we compute the latency
+		// and update the metric.
+		latency := time.Since(lastPingSentAt)
+		s.logger.Trace(
+			"PONG received",
+			commontypes.LogFields{
+				"remotePeerID": remotePeerID, "msg": pongMsg, "latency_seconds": latency.Seconds(),
+			},
+		)
+		metrics.roundTripLatencySeconds.Observe(latency.Seconds())
+		return true
+	} else {
+		if expectedPongMsg != nil {
+			s.logger.Debug("invalid (conflicting) PONG received. The typical cause are restarts of the underlying network connection.", commontypes.LogFields{
+				"remotePeerID": remotePeerID, "msg": pongMsg, "expectedMsg": expectedPongMsg,
+			})
+		} else {
+			s.logger.Debug("invalid (unexpected) PONG received. The typical cause are restarts of the underlying network connection.", commontypes.LogFields{
+				"remotePeerID": remotePeerID, "msg": pongMsg,
+			})
+		}
+		metrics.invalidMessagesReceivedTotal.Inc()
+		return false
+	}
+}

--- a/networking/rageping/types.go
+++ b/networking/rageping/types.go
@@ -1,0 +1,147 @@
+package rageping
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/internal/loghelper"
+	"github.com/smartcontractkit/libocr/ragep2p"
+	ragetypes "github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+type LatencyMetricsService interface {
+	// Adds the given list of peers to the service. Registering the same peers multiple times is supported, upon each
+	// registration, an internal reference count is incremented.
+	RegisterPeers(peerIDs []ragetypes.PeerID)
+
+	// Decremented the internal reference count for each of the given peers. Only if a reference count reaches zero,
+	// the execution of the core ping/pong protocol is stopped.
+	UnregisterPeers(peerIDs []ragetypes.PeerID)
+
+	// Unregisters all peers (if any) and releases all resources.
+	Close()
+}
+
+type LatencyMetricsServiceConfig struct {
+	// The size of the PING message to be sent in bytes.
+	// The minimal allowed value is 20 (4 bytes for the message type, 16 bytes for a random tag).
+	// The size of the corresponding PONG message is constant (36 bytes: 4 bytes for message type, 32 bytes hash).
+	PingSize int
+
+	// The minimal, and maximal configured delay between two consecutive requests.
+	// The actual delay used is computed uniformly at random from the interval [MinPeriod, maxPeriod].
+	MinPeriod time.Duration
+	MaxPeriod time.Duration
+
+	// The maximal time to wait for a PONG message in response to a sent PING message, before considering the request to
+	// be failed. Note: As long no PONG message was received for an active PING message and no Timeout was reached, the
+	// protocol does not send out a new PING message.
+	Timeout time.Duration
+
+	// Extra time to wait until the first PING messages are sent out.
+	// Useful, e.g., to avoid failing PING messages during testing when all nodes are started roughly at the same time.
+	StartupDelay time.Duration
+
+	// The bucket values for the prometheus.Histogram metric capturing the round-trip latencies, to be specified in
+	// fractional seconds.
+	//
+	// Example: The bucket values [0.05, 0.10, 0.5, 1.0, 5.0] capture latencies in the following ranges:
+	//  -   0 ms <= x <=  50 ms
+	//  -  50 ms <  x <= 100 ms
+	//  - 100 ms <  x <= 500 ms
+	//  - 500 ms <  x <=   1 s
+	//  -   1 s  <  x <=   5 s
+	//  -   5 s  <  x <= infinity
+	//
+	// The value `nil` may be specified to use a set of pre-configured default bucket values.
+	// See DefaultLatencyBuckets() for the default values.
+	Buckets []float64
+}
+
+// Default latency histogram bucket boundaries, denoted in seconds
+func DefaultLatencyBuckets() []float64 {
+	return []float64{
+		0.025, 0.050, 0.075, 0.100,
+		0.150, 0.200, 0.250, 0.300,
+		0.400, 0.500,
+		0.750, 1.000,
+		2.500, 5.000,
+		10.000,
+	}
+}
+
+// Initializes a new instance for collecting latency metrics. Metrics are collected for each passed configuration
+// (PING request size, periods, ...). The passed configurations must be pairwise distinct, i.e., do not pass the same
+// configuration multiple times as parameter. (This minor restriction is a result of how the underlying streams are
+// initialized, and may be lifted if needed.)
+func NewLatencyMetricsService(
+	host *ragep2p.Host,
+	registerer prometheus.Registerer,
+	logger loghelper.LoggerWithContext,
+	configs []*LatencyMetricsServiceConfig,
+) LatencyMetricsService {
+	// Create child logger to make finding rageping-related logs easier.
+	logger = logger.MakeChild(commontypes.LogFields{"in": "rageping"})
+
+	if len(configs) == 0 {
+		logger.Warn("latency metrics service not starting, no configs provided", commontypes.LogFields{
+			"hostPeerID": host.ID(),
+		})
+	}
+
+	// Create a latencyMetricsService instance per configuration and manage all of them using a
+	// latencyMetricsServiceGroup, i.e., a rapper which forwards all calls to the individual instances.
+	serviceGroup := latencyMetricsServiceGroup{make([]LatencyMetricsService, 0, len(configs))}
+	for _, config := range configs {
+		if config.PingSize < minPingSize {
+			logger.Error(
+				"invalid ping size, ignoring configuration",
+				commontypes.LogFields{"pingSize": config.PingSize, "minPingSize": minPingSize},
+			)
+			continue
+		}
+
+		serviceInstance := latencyMetricsService{
+			host,
+			registerer,
+			logger,
+			make(map[ragetypes.PeerID]*latencyMetricsPeerState),
+			config,
+			config.getStreamLimits(),
+			sync.Mutex{},
+		}
+		serviceGroup.instances = append(serviceGroup.instances, &serviceInstance)
+	}
+
+	return &serviceGroup
+}
+
+// The default configurations run the protocol for two different ping sizes:
+//   - a small 20 B ping, every 10-20s (10 second timeout)
+//   - a larger 200 KiB ping, every 2-3min (30 second timeout)
+//
+// During testing, significant latency differences between the two message sizes have been found. So it makes sense to
+// run the protocol for different ping sizes. However, there is no particular reason to use those exact values. Timeouts
+// and startup delay are set quite conservatively. There is no need to make those tighter.
+func DefaultConfigs() []*LatencyMetricsServiceConfig {
+	return []*LatencyMetricsServiceConfig{
+		{
+			20,               // PingSize, smallest allowed size: 20 bytes
+			10 * time.Second, // MinPeriod
+			20 * time.Second, // MaxPeriod
+			10 * time.Second, // Timeout
+			30 * time.Second, // StartupDelay
+			nil,              // use default latency buckets
+		},
+		{
+			200 * 1024,       // PingSize, 200 KiB
+			2 * time.Minute,  // MinPeriod
+			3 * time.Minute,  // MaxPeriod
+			30 * time.Second, // Timeout
+			30 * time.Second, // StartupDelay
+			nil,              // use default latency buckets
+		},
+	}
+}

--- a/offchainreporting2/types/alias.go
+++ b/offchainreporting2/types/alias.go
@@ -6,8 +6,8 @@ import "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 type ConfigDigestPrefix = types.ConfigDigestPrefix
 
 const (
-	ConfigDigestPrefixEVM        ConfigDigestPrefix = types.ConfigDigestPrefixEVM
-	ConfigDigestPrefixTerra      ConfigDigestPrefix = types.ConfigDigestPrefixTerra
+	// Deprecated: Use equivalent offchainreporting2plus/types.ConfigDigestPrefixEVMSimple instead
+	ConfigDigestPrefixEVM        ConfigDigestPrefix = types.ConfigDigestPrefixEVM //nolint:staticcheck
 	ConfigDigestPrefixSolana     ConfigDigestPrefix = types.ConfigDigestPrefixSolana
 	ConfigDigestPrefixStarknet   ConfigDigestPrefix = types.ConfigDigestPrefixStarknet
 	ConfigDigestPrefixMercuryV02 ConfigDigestPrefix = types.ConfigDigestPrefixMercuryV02

--- a/offchainreporting2plus/chains/evmutil/config_digest.go
+++ b/offchainreporting2plus/chains/evmutil/config_digest.go
@@ -59,7 +59,7 @@ func configDigest(
 		// assertion
 		panic("copy too little data")
 	}
-	if types.ConfigDigestPrefixEVM != 1 {
+	if types.ConfigDigestPrefixEVMSimple != 1 {
 		// assertion
 		panic("wrong ConfigDigestPrefix")
 	}

--- a/offchainreporting2plus/chains/evmutil/offchain_config_digester.go
+++ b/offchainreporting2plus/chains/evmutil/offchain_config_digester.go
@@ -47,5 +47,5 @@ func (d EVMOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (types.
 }
 
 func (d EVMOffchainConfigDigester) ConfigDigestPrefix() (types.ConfigDigestPrefix, error) {
-	return types.ConfigDigestPrefixEVM, nil
+	return types.ConfigDigestPrefixEVMSimple, nil
 }

--- a/offchainreporting2plus/internal/managed/managed_mercury_oracle.go
+++ b/offchainreporting2plus/internal/managed/managed_mercury_oracle.go
@@ -206,6 +206,7 @@ func RunManagedMercuryOracle(
 			}
 			reportingPlugin := &mercuryshim.MercuryReportingPlugin{
 				reportingPluginConfig,
+				logger,
 				mercuryPlugin,
 				mercuryPluginInfo.Limits,
 			}

--- a/offchainreporting2plus/internal/mercuryshim/mercuryshims.go
+++ b/offchainreporting2plus/internal/mercuryshim/mercuryshims.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/internal/loghelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
@@ -114,6 +116,7 @@ func ReportingPluginLimits(mercuryPluginLimits ocr3types.MercuryPluginLimits) oc
 
 type MercuryReportingPlugin struct {
 	Config       ocr3types.ReportingPluginConfig
+	Logger       loghelper.LoggerWithContext
 	Plugin       ocr3types.MercuryPlugin
 	PluginLimits ocr3types.MercuryPluginLimits
 }
@@ -153,6 +156,12 @@ func (p *MercuryReportingPlugin) Query(ctx context.Context, outctx ocr3types.Out
 }
 
 func (p *MercuryReportingPlugin) Observation(ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query) (types.Observation, error) {
+	p.Logger.Debug("MercuryReportingPlugin: Observation", commontypes.LogFields{
+		"seqNr": outctx.SeqNr,
+		"epoch": outctx.Epoch, // nolint: staticcheck
+		"round": outctx.Round, // nolint: staticcheck
+	})
+
 	previousOutcomeDeserialized, err := deserializeMercuryReportingPluginOutcome(outctx.PreviousOutcome)
 	if err != nil {
 		return nil, err
@@ -180,6 +189,12 @@ func (p *MercuryReportingPlugin) ObservationQuorum(outctx ocr3types.OutcomeConte
 }
 
 func (p *MercuryReportingPlugin) Outcome(outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation) (ocr3types.Outcome, error) {
+	p.Logger.Debug("MercuryReportingPlugin: Outcome", commontypes.LogFields{
+		"seqNr": outctx.SeqNr,
+		"epoch": outctx.Epoch, // nolint: staticcheck
+		"round": outctx.Round, // nolint: staticcheck
+	})
+
 	previousOutcomeDeserialized, err := deserializeMercuryReportingPluginOutcome(outctx.PreviousOutcome)
 	if err != nil {
 		return nil, err

--- a/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_follower.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_follower.go
@@ -373,11 +373,20 @@ func (outgen *outcomeGenerationState[RI]) tryProcessProposalPool() {
 					), nil
 				},
 			)
-			if !ok || err != nil {
-				outgen.logger.Warn("dropping MessageProposal that contains an invalid observation", commontypes.LogFields{
-					"seqNr": outgen.sharedState.seqNr,
-					"error": err,
+			if !ok {
+				outgen.logger.Error("dropping MessageProposal containing observation that could not be validated", commontypes.LogFields{
+					"seqNr":    outgen.sharedState.seqNr,
+					"observer": aso.Observer,
 				})
+				return
+			}
+			if err != nil {
+				outgen.logger.Warn("dropping MessageProposal that contains an invalid observation", commontypes.LogFields{
+					"seqNr":    outgen.sharedState.seqNr,
+					"error":    err,
+					"observer": aso.Observer,
+				})
+				return
 			}
 
 			if aso.Observer == outgen.id {

--- a/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_leader.go
+++ b/offchainreporting2plus/internal/ocr3/protocol/outcome_generation_leader.go
@@ -294,12 +294,20 @@ func (outgen *outcomeGenerationState[RI]) messageObservation(msg MessageObservat
 			), nil
 		},
 	)
-	if !ok || err != nil {
+	if !ok {
+		outgen.logger.Error("dropping MessageObservation that could not be validated", commontypes.LogFields{
+			"sender": sender,
+			"seqNr":  outgen.sharedState.seqNr,
+		})
+		return
+	}
+	if err != nil {
 		outgen.logger.Warn("dropping MessageObservation carrying invalid Observation", commontypes.LogFields{
 			"sender": sender,
 			"seqNr":  outgen.sharedState.seqNr,
 			"error":  err,
 		})
+		return
 	}
 
 	quorum, ok := outgen.ObservationQuorum(outgen.leaderState.query)

--- a/offchainreporting2plus/types/config_digest.go
+++ b/offchainreporting2plus/types/config_digest.go
@@ -16,18 +16,22 @@ type ConfigDigestPrefix uint16
 // whatever chain you're targeting.
 const (
 	_                                        ConfigDigestPrefix = 0 // reserved to prevent errors where a zero-default creeps through somewhere
-	ConfigDigestPrefixEVM                    ConfigDigestPrefix = 1 // TODO: rename to ConfigDigestPrefixEVMSimple in the future
-	ConfigDigestPrefixTerra                  ConfigDigestPrefix = 2
-	ConfigDigestPrefixSolana                 ConfigDigestPrefix = 3
-	ConfigDigestPrefixStarknet               ConfigDigestPrefix = 4
-	_                                                           = 5 // reserved, not sure for what
-	ConfigDigestPrefixMercuryV02             ConfigDigestPrefix = 6 // Mercury v0.2 and v0.3
-	ConfigDigestPrefixEVMThresholdDecryption ConfigDigestPrefix = 7 // Run Threshold/S4 plugins as part of another product under one contract.
-	ConfigDigestPrefixEVMS4                  ConfigDigestPrefix = 8 // Run Threshold/S4 plugins as part of another product under one contract.
-	ConfigDigestPrefixLLO                    ConfigDigestPrefix = 9 // Mercury v1
+	ConfigDigestPrefixEVMSimple              ConfigDigestPrefix = 0x0001
+	ConfigDigestPrefixTerra                  ConfigDigestPrefix = 0x0002
+	ConfigDigestPrefixSolana                 ConfigDigestPrefix = 0x0003
+	ConfigDigestPrefixStarknet               ConfigDigestPrefix = 0x0004
+	_                                                           = 0x0005 // reserved, not sure for what
+	ConfigDigestPrefixMercuryV02             ConfigDigestPrefix = 0x0006 // Mercury v0.2 and v0.3
+	ConfigDigestPrefixEVMThresholdDecryption ConfigDigestPrefix = 0x0007 // Run Threshold/S4 plugins as part of another product under one contract.
+	ConfigDigestPrefixEVMS4                  ConfigDigestPrefix = 0x0008 // Run Threshold/S4 plugins as part of another product under one contract.
+	ConfigDigestPrefixLLO                    ConfigDigestPrefix = 0x0009 // Mercury v1
+	ConfigDigestPrefixCCIPMultiRole          ConfigDigestPrefix = 0x000a // CCIP multi role
 
 	ConfigDigestPrefixOCR1 ConfigDigestPrefix = 0xEEEE // we translate ocr1 config digest to ocr2 config digests in the networking layer
 	_                      ConfigDigestPrefix = 0xFFFF // reserved for future use
+
+	// Deprecated: Use equivalent ConfigDigestPrefixEVMSimple instead
+	ConfigDigestPrefixEVM ConfigDigestPrefix = ConfigDigestPrefixEVMSimple
 )
 
 func ConfigDigestPrefixFromConfigDigest(configDigest ConfigDigest) ConfigDigestPrefix {

--- a/ragep2p/ragep2p.go
+++ b/ragep2p/ragep2p.go
@@ -884,11 +884,11 @@ type TokenBucketParams struct {
 func (ho *Host) NewStream(
 	other types.PeerID,
 	streamName string,
-	outgoingBufferSize int,
-	incomingBufferSize int,
+	outgoingBufferSize int, // number of messages that fit in the outgoing buffer
+	incomingBufferSize int, // number of messages that fit in the incoming buffer
 	maxMessageLength int,
-	messagesLimit TokenBucketParams,
-	bytesLimit TokenBucketParams,
+	messagesLimit TokenBucketParams, // rate limit for incoming messages
+	bytesLimit TokenBucketParams, // rate limit for incoming messages
 ) (*Stream, error) {
 	if other == ho.id {
 		return nil, fmt.Errorf("stream with self is forbidden")


### PR DESCRIPTION
- rageping collects latency metrics with all conncted ragep2p peers
- rename ConfigDigestPrefixEVM -> types.ConfigDigestPrefixEVMSimple, add ConfigDigestPrefixCCIPMultiRole
- discard observations that fail OCR3Plugin.ValidateObservation check
- align OCR3 report attestation protocol more closely with paper
- logging & doc improvements

Based on 41ba32903f17a1de131be7d3bae3bf7a82bf5e49