### PR TITLE
Improvements:

### DIFF
--- a/networking/ocr_endpoint_v2.go
+++ b/networking/ocr_endpoint_v2.go
@@ -190,7 +190,6 @@ func (o *ocrEndpointV2) Start() error {
 	}
 
 	for oid := range o.streams {
-		oid := oid
 		o.subs.Go(func() {
 			o.runRecv(oid)
 		})
@@ -322,7 +321,6 @@ func (o *ocrEndpointV2) Broadcast(payload []byte) {
 	var subs subprocesses.Subprocesses
 	defer subs.Wait()
 	for oracleID := range o.peerMapping {
-		oracleID := oracleID
 		subs.Go(func() {
 			o.SendTo(payload, oracleID)
 		})

--- a/offchainreporting2plus/chains/evmutil/evm.go
+++ b/offchainreporting2plus/chains/evmutil/evm.go
@@ -35,7 +35,6 @@ func ContractConfigFromConfigSetEvent(changed ocr2aggregator.OCR2AggregatorConfi
 	}
 	signers := []types.OnchainPublicKey{}
 	for _, addr := range changed.Signers {
-		addr := addr
 		signers = append(signers, types.OnchainPublicKey(addr[:]))
 	}
 	return types.ContractConfig{

--- a/offchainreporting2plus/internal/config/ocr2config/serialize.go
+++ b/offchainreporting2plus/internal/config/ocr2config/serialize.go
@@ -164,7 +164,6 @@ func enprotoOffchainConfig(o offchainConfig) OffchainConfigProto {
 	}
 	offchainPublicKeys := make([][]byte, 0, len(o.OffchainPublicKeys))
 	for _, k := range o.OffchainPublicKeys {
-		k := k // have to copy or we append the same key over and over
 		offchainPublicKeys = append(offchainPublicKeys, k[:])
 	}
 	maxDurationInitializationNanoseconds := (*uint64)(nil)
@@ -202,7 +201,6 @@ func enprotoOffchainConfig(o offchainConfig) OffchainConfigProto {
 func enprotoSharedSecretEncryptions(e config.SharedSecretEncryptions) SharedSecretEncryptionsProto {
 	encs := make([][]byte, 0, len(e.Encryptions))
 	for _, enc := range e.Encryptions {
-		enc := enc
 		encs = append(encs, enc[:])
 	}
 	return SharedSecretEncryptionsProto{

--- a/offchainreporting2plus/internal/config/ocr3config/serialize.go
+++ b/offchainreporting2plus/internal/config/ocr3config/serialize.go
@@ -166,7 +166,6 @@ func enprotoOffchainConfig(o offchainConfig) OffchainConfigProto {
 	}
 	offchainPublicKeys := make([][]byte, 0, len(o.OffchainPublicKeys))
 	for _, k := range o.OffchainPublicKeys {
-		k := k // have to copy or we append the same key over and over
 		offchainPublicKeys = append(offchainPublicKeys, k[:])
 	}
 	maxDurationInitializationNanoseconds := (*uint64)(nil)
@@ -205,7 +204,6 @@ func enprotoOffchainConfig(o offchainConfig) OffchainConfigProto {
 func enprotoSharedSecretEncryptions(e config.SharedSecretEncryptions) SharedSecretEncryptionsProto {
 	encs := make([][]byte, 0, len(e.Encryptions))
 	for _, enc := range e.Encryptions {
-		enc := enc
 		encs = append(encs, enc[:])
 	}
 	return SharedSecretEncryptionsProto{

--- a/ragep2p/ragep2p.go
+++ b/ragep2p/ragep2p.go
@@ -597,7 +597,6 @@ func (ho *Host) dialLoop() {
 		}
 		ho.peersMu.Unlock()
 		for _, p := range peers {
-			p := p // copy for goroutine
 			ds := dialStates[p.other]
 			dialProcesses.Go(func() {
 				p.connLifeCycleMu.Lock()


### PR DESCRIPTION
- Fix a bug in report attestation that could leak memory when a protocol instance never produces reports
- Adjust code to take advantage of new go1.22 loop variable semantics

Based on a84d7f40f264c0b5ef48a7000a56a17d5f90950a